### PR TITLE
Restore Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,16 @@ jobs:
           command: |
             tox
 
-  test_py36: &test-template
+  test_py35: &test-template
     docker:
-      - image: python:3.6
+      - image: python:3.5
 
     working_directory: ~/repo
 
     environment:
       PIP_PREFER_BINARY: true
       PIP_PROGRESS_BAR: "off"
-      TOXENV: py36
+      TOXENV: py35
 
     steps:
       - checkout
@@ -43,6 +43,14 @@ jobs:
           name: run tests
           command: |
             tox
+
+  test_py36:
+    <<: *test-template
+    docker:
+      - image: python:3.6
+
+    environment:
+      TOXENV: py36
 
   test_py37:
     <<: *test-template
@@ -79,6 +87,9 @@ workflows:
   build_and_test:
     jobs:
       - quality
+      - test_py35:
+          requires:
+            - quality
       - test_py36:
           requires:
             - quality

--- a/src/czml3/core.py
+++ b/src/czml3/core.py
@@ -83,7 +83,7 @@ class Packet(BaseCZMLObject):
         position=None,
         billboard=None,
         label=None,
-        path=None,
+        path=None
     ):
         if id is None:
             id = str(uuid4())

--- a/src/czml3/enums.py
+++ b/src/czml3/enums.py
@@ -1,4 +1,19 @@
-from enum import Enum, auto
+try:
+    from enum import Enum, auto  # type: ignore
+except ImportError:
+    # We are in Python 3.5
+    # https://docs.python.org/3.5/library/enum.html#autonumber
+    from enum import Enum as _BaseEnum
+
+    class Enum(_BaseEnum):  # type: ignore
+        def __new__(cls, *args):
+            value = len(cls.__members__) + 1
+            obj = object.__new__(cls)
+            obj._value_ = value
+            return obj
+
+    def auto():
+        pass
 
 
 class InterpolationAlgorithms(Enum):

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -25,7 +25,7 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
         interpolationAlgorithm=None,
         interpolationDegree=None,
         referenceFrame=None,
-        cartesian=None,
+        cartesian=None
     ):
         if isinstance(cartesian, list):
             cartesian = Cartesian3Value(values=cartesian)
@@ -90,7 +90,7 @@ class Billboard(BaseCZMLObject, HasAlignment):
         show=None,
         scale=None,
         horizontalOrigin=None,
-        verticalOrigin=None,
+        verticalOrigin=None
     ):
         if isinstance(image, str):
             image = Uri(uri=image)
@@ -144,7 +144,7 @@ class Clock(BaseCZMLObject):
         currentTime=None,
         multiplier=1.0,
         range=ClockRanges.LOOP_STOP,
-        step=ClockSteps.SYSTEM_CLOCK_MULTIPLIER,
+        step=ClockSteps.SYSTEM_CLOCK_MULTIPLIER
     ):
         self._current_time = currentTime
         self._multiplier = multiplier
@@ -293,7 +293,7 @@ class Label(BaseCZMLObject, HasAlignment):
         showBackground=None,
         horizontalOrigin=None,
         verticalOrigin=None,
-        outlineWidth=1.0,
+        outlineWidth=1.0
     ):
         self._show = show
         self._text = text


### PR DESCRIPTION
Python 3.5 is a pain in the neck because the dictionaries were not ordered (I had forgotten about this!). I fixed some things but I guess we would need to rewrite some parts using https://docs.python.org/3.5/library/collections.html#collections.OrderedDict.