### PR TITLE
Make get_color more robust

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -113,7 +113,7 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
             try:
                 n = int(color.rsplit("#")[-1], 16)
                 return 0 <= n <= 0xFFFFFFFF
-            except:
+            except ValueError:
                 return False
         return False
 

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -89,8 +89,37 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
     rgbaf = attr.ib(default=None)
 
     @classmethod
+    def is_valid(cls, color):
+        """Determines if the input is a valid color"""
+        # [R, G, B] or [R, G, B, A]
+        if (
+            isinstance(color, list)
+            and all([issubclass(type(v), int) for v in color])
+            and (3 <= len(color) <= 4)
+        ):
+            return all(0 <= v <= 255 for v in color)
+        # [r, g, b] or [r, g, b, a] (float)
+        elif (
+            isinstance(color, list)
+            and all([issubclass(type(v), float) for v in color])
+            and (3 <= len(color) <= 4)
+        ):
+            return all(0 <= v <= 1 for v in color)
+        # Hexadecimal RGBA
+        elif issubclass(type(color), int):
+            return 0 <= color <= 0xFFFFFFFF
+        # RGBA string
+        elif isinstance(color, str):
+            try:
+                n = int(color.rsplit("#")[-1], 16)
+                return 0 <= n <= 0xFFFFFFFF
+            except:
+                return False
+        return False
+
+    @classmethod
     def from_list(cls, color):
-        if all(isinstance(v, int) for v in color):
+        if all(issubclass(type(v), int) for v in color):
             if len(color) == 3:
                 color = color + [255]
             else:

--- a/src/czml3/utils.py
+++ b/src/czml3/utils.py
@@ -12,9 +12,9 @@ def get_color_list(timestamps, colors, rgbaf=False):
 
     Parameters
     ----------
-    :param list(str) timestamps: The li"st of the timestamps (ISO 8601 date or seconds since epoch)
+    :param list(str) timestamps: The list of the timestamps (ISO 8601 date or seconds since epoch)
     :param str/int/list colors : A list of valid colors
-    :param bool rgbaf: If set to True, returns rgbaf values, else return rgba
+    :param bool rgbaf: If set to True, returns rgbaf values, else return rgba values
     """
     # Check if colors is a valid list of colors
     if all(Color.is_valid(v) for v in colors):

--- a/src/czml3/utils.py
+++ b/src/czml3/utils.py
@@ -1,4 +1,50 @@
+from functools import reduce
+
 from .properties import Color
+from .types import RgbafValue, RgbaValue
+
+
+def get_color_list(timestamps, colors, rgbaf=False):
+    """
+    Given a list of valid colors (rgb/rgba tuples, shorthand hex string or integer representation) and a list of
+    time-stamps, create a Color object with rgba/rgbaf values of the form: [time_0, r_0, g_0, b_0,..., time_k, r_k,
+    g_k, b_k]
+
+    Parameters
+    ----------
+    :param list(str) timestamps: The li"st of the timestamps (ISO 8601 date or seconds since epoch)
+    :param str/int/list colors : A list of valid colors
+    :param bool rgbaf: If set to True, returns rgbaf values, else return rgba
+    """
+    # Check if colors is a valid list of colors
+    if all(Color.is_valid(v) for v in colors):
+        color_lst = list(map(get_color, colors))
+    else:
+        raise ValueError("Invalid input")
+
+    # Quick function to convert between rgba-rgbaf easier
+    if rgbaf:
+        color_r = (
+            lambda c: c.rgbaf.values
+            if c.rgbaf
+            else list(map(lambda x: x / 255, c.rgba.values))
+        )
+    else:
+        color_r = (
+            lambda c: c.rgba.values
+            if c.rgba
+            else list(map(lambda x: round(x * 255), c.rgbaf.values))
+        )
+
+    # Get combined list of timestamps and colors
+    time_colr = [[time] + color_r(c) for time, c in zip(timestamps, color_lst)]
+    # Flatten list
+    time_colr = reduce(lambda x, y: x + y, time_colr)
+
+    if rgbaf:
+        return Color(rgbaf=RgbafValue(values=time_colr))
+    else:
+        return Color(rgba=RgbaValue(values=time_colr))
 
 
 def get_color(color):
@@ -10,9 +56,8 @@ def get_color(color):
     Parameters
     ----------
 
-    color:
-        :param color str/int/list: Depending on the type, ``color`` can be either a hexadecimal rgb/rgba color value or
-        a tuple in the form of [r, g, b, a] or [r, g, b]. ``color`` also accepts a list of valid colors.
+    :param  str/int/list color: Depending on the type, ``color`` can be either a hexadecimal rgb/rgba color value or
+        a tuple in the form of [r, g, b, a] or [r, g, b].
 
     """
     # Color.from_string, Color.from_int, ...
@@ -24,9 +69,4 @@ def get_color(color):
         # If it is a valid color in list form, simply return it
         if Color.is_valid(color):
             return Color.from_list(color)
-        # If not, check whether this is a valid list of colors:
-        elif all(Color.is_valid(v) for v in color):
-            return list(map(get_color, color))
-        # map
-        #    return [get_color(v) for v in color]
     raise ValueError("Invalid input")

--- a/src/czml3/utils.py
+++ b/src/czml3/utils.py
@@ -2,12 +2,31 @@ from .properties import Color
 
 
 def get_color(color):
+
+    """
+    A helper function to make color setting more versatile. What the ``color`` parameter determines depends on
+    its type.
+
+    Parameters
+    ----------
+
+    color:
+        :param color str/int/list: Depending on the type, ``color`` can be either a hexadecimal rgb/rgba color value or
+        a tuple in the form of [r, g, b, a] or [r, g, b]. ``color`` also accepts a list of valid colors.
+
+    """
     # Color.from_string, Color.from_int, ...
     if isinstance(color, str) and 6 <= len(color) <= 10:
         return Color.from_str(color)
-    elif isinstance(color, int):
-        return Color.from_hex(color)
-    elif isinstance(color, list) and len(color) <= 4:
-        return Color.from_list(color)
-    else:
-        raise ValueError("Invalid input")
+    elif issubclass(int, type(color)):
+        return Color.from_hex(int(color))
+    elif isinstance(color, list):
+        # If it is a valid color in list form, simply return it
+        if Color.is_valid(color):
+            return Color.from_list(color)
+        # If not, check whether this is a valid list of colors:
+        elif all(Color.is_valid(v) for v in color):
+            return list(map(get_color, color))
+        # map
+        #    return [get_color(v) for v in color]
+    raise ValueError("Invalid input")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -36,6 +36,8 @@ from czml3.types import (
     DistanceDisplayConditionValue,
     IntervalValue,
     NearFarScalarValue,
+    RgbafValue,
+    RgbaValue,
     Sequence,
     UnitQuaternionValue,
 )
@@ -170,6 +172,28 @@ def test_material_solid_color():
 
     pol_mat = PolylineMaterial(solidColor=SolidColorMaterial.from_list([200, 100, 30]))
     assert repr(pol_mat) == expected_result
+
+
+def test_color_isvalid():
+    assert Color.is_valid([255, 204, 0, 55])
+    assert Color.is_valid([255, 204, 55])
+    assert Color.is_valid(0xFF3223)
+    assert Color.is_valid(32)
+    assert Color.is_valid(0xFF322332)
+    assert Color.is_valid("#FF3223")
+    assert Color.is_valid("#FF322332")
+
+
+def test_color_isvalid_false():
+    assert Color.is_valid([256, 204, 0, 55]) is False
+    assert Color.is_valid([-204, 0, 55]) is False
+    assert Color.is_valid([249.1, 204.3, 55.4]) is False
+    assert Color.is_valid([255, 204]) is False
+    assert Color.is_valid([255, 232, 300]) is False
+    assert Color.is_valid(0xFF3223324) is False
+    assert Color.is_valid(-3) is False
+    assert Color.is_valid("totally valid color") is False
+    assert Color.is_valid("#FF322332432") is False
 
 
 def test_material_image():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -36,8 +36,6 @@ from czml3.types import (
     DistanceDisplayConditionValue,
     IntervalValue,
     NearFarScalarValue,
-    RgbafValue,
-    RgbaValue,
     Sequence,
     UnitQuaternionValue,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,20 @@ from czml3.types import RgbafValue, RgbaValue
 from czml3.utils import get_color
 
 
+def test_get_color_list_of_colors():
+    expected_color = [
+        Color(rgba=RgbaValue(values=[255, 204, 0, 255])),
+        Color(rgba=RgbaValue(values=[255, 204, 0, 255])),
+        Color(rgbaf=RgbafValue(values=[1.0, 0.8, 0.0, 1.0])),
+    ]
+    assert get_color(["#ffcc00", 0xFFCC00, [1.0, 0.8, 0.0, 1.0]]) == expected_color
+    assert get_color(["#ffcc00ff", 0xFFCC00FF, [1.0, 0.8, 0.0, 1.0]]) == expected_color
+    assert (
+        get_color([[255, 204, 0], [255, 204, 0, 255], [1.0, 0.8, 0.0, 1.0]])
+        == expected_color
+    )
+
+
 def test_get_color_rgba():
     expected_color = Color(rgba=RgbaValue(values=[255, 204, 0, 255]))
 
@@ -24,7 +38,7 @@ def test_get_color_rgbaf():
     assert get_color([1.0, 0.8, 0.0, 1.0]) == expected_color
 
 
-@pytest.mark.parametrize("input", ["a", [0, 0, 0, 0, 0], [1.0, 1.0]])
+@pytest.mark.parametrize("input", ["a", [0, 0, 0, 0, -300], [0.3, 0.3, 0.1, 1.0, 1.0]])
 def test_get_color_invalid_input_raises_error(input):
     with pytest.raises(ValueError):
         get_color(input)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,21 +2,83 @@ import pytest
 
 from czml3.properties import Color
 from czml3.types import RgbafValue, RgbaValue
-from czml3.utils import get_color
+from czml3.utils import get_color, get_color_list
 
 
-def test_get_color_list_of_colors():
-    expected_color = [
-        Color(rgba=RgbaValue(values=[255, 204, 0, 255])),
-        Color(rgba=RgbaValue(values=[255, 204, 0, 255])),
-        Color(rgbaf=RgbafValue(values=[1.0, 0.8, 0.0, 1.0])),
-    ]
-    assert get_color(["#ffcc00", 0xFFCC00, [1.0, 0.8, 0.0, 1.0]]) == expected_color
-    assert get_color(["#ffcc00ff", 0xFFCC00FF, [1.0, 0.8, 0.0, 1.0]]) == expected_color
+def test_get_color_list_of_colors_rgba():
+    expected_color = Color(
+        rgba=RgbaValue(
+            values=[
+                "0000-00-00T00:00:00Z",
+                255,
+                204,
+                0,
+                255,
+                "9999-12-31T24:00:00Z",
+                255,
+                204,
+                0,
+                255,
+            ]
+        )
+    )
     assert (
-        get_color([[255, 204, 0], [255, 204, 0, 255], [1.0, 0.8, 0.0, 1.0]])
+        get_color_list(
+            ["0000-00-00T00:00:00Z", "9999-12-31T24:00:00Z"],
+            [[1.0, 0.8, 0.0, 1.0], 0xFFCC00FF],
+        )
         == expected_color
     )
+    assert (
+        get_color_list(
+            ["0000-00-00T00:00:00Z", "9999-12-31T24:00:00Z"], ["#ffcc00ff", 0xFFCC00]
+        )
+        == expected_color
+    )
+
+
+def test_get_color_list_of_colors_rgbaf():
+    expected_color = Color(
+        rgbaf=RgbafValue(
+            values=[
+                "0000-00-00T00:00:00Z",
+                1.0,
+                0.8,
+                0.0,
+                1.0,
+                "9999-12-31T24:00:00Z",
+                1.0,
+                0.8,
+                0.0,
+                1.0,
+            ]
+        )
+    )
+    assert (
+        get_color_list(
+            ["0000-00-00T00:00:00Z", "9999-12-31T24:00:00Z"],
+            [[1.0, 0.8, 0.0, 1.0], 0xFFCC00],
+            rgbaf=True,
+        )
+        == expected_color
+    )
+    assert (
+        get_color_list(
+            ["0000-00-00T00:00:00Z", "9999-12-31T24:00:00Z"],
+            [[255, 204, 0], 0xFFCC00FF],
+            rgbaf=True,
+        )
+        == expected_color
+    )
+
+
+def test_get_color_list_of_colors_invalid():
+    with pytest.raises(ValueError):
+        get_color_list(
+            ["0000-00-00T00:00:00Z", "9999-12-31T24:00:00Z"],
+            [[300, 204, 0], -0xFFCC00FF],
+            rgbaf=True,
+        )
 
 
 def test_get_color_rgba():


### PR DESCRIPTION
Partially adresses #42 
* Adds an ``is_valid`` class method for sanity checking

* Accepts ``int`` subtypes (e.g. ``np.int``)

* Supports list of colors.
     I personally think this is a helpful addition since CZML supports arrays of time-stamped color components, however I'm a bit conflicted in regards to the implementation. For one, the current function parses ``[200, 50, 30]`` as an RGB triplet but ``[200, 50]`` as a list of ``int``s (``[0xC8, 0x32]``)  which is certainly counter-intuitive. Also, I believe that it'd be more useful to break up ``get_color`` into ``get_color`` and ``get_color_list``. ``get_color_list`` will take an array of colors and an array of time-stamps as input and return a single ``Color`` object 

Any suggestions are more than welcome!