### PR TITLE
Colors/rgba/rgbaf: support tuple-shaped color lists

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -142,6 +142,20 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
             and (3 <= len(color) <= 4)
         ):
             return all(0 <= v <= 1 for v in color)
+        # (R, G, B) or (R, G, B, A)
+        if (
+            isinstance(color, tuple)
+            and all([issubclass(type(v), int) for v in color])
+            and (3 <= len(color) <= 4)
+        ):
+            return all(0 <= v <= 255 for v in color)
+        # (r, g, b) or (r, g, b, a) (float)
+        elif (
+            isinstance(color, tuple)
+            and all([issubclass(type(v), float) for v in color])
+            and (3 <= len(color) <= 4)
+        ):
+            return all(0 <= v <= 1 for v in color)
         # Hexadecimal RGBA
         elif issubclass(type(color), int):
             return 0 <= color <= 0xFFFFFFFF
@@ -170,6 +184,10 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
                 color = color[:]
 
             return cls(rgbaf=RgbafValue(values=color))
+
+    @classmethod
+    def from_tuple(cls, color):
+        return cls(list(color))
 
     @classmethod
     def from_hex(cls, color):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -283,6 +283,7 @@ def test_color_isvalid():
     assert Color.is_valid(0xFF322332)
     assert Color.is_valid("#FF3223")
     assert Color.is_valid("#FF322332")
+    assert Color.is_valid((0.127568, 0.566949, 0.550556, 1.0))
 
 
 def test_color_isvalid_false():
@@ -295,6 +296,7 @@ def test_color_isvalid_false():
     assert Color.is_valid(-3) is False
     assert Color.is_valid("totally valid color") is False
     assert Color.is_valid("#FF322332432") is False
+    assert Color.is_valid((0.127568, 0.566949, 0.550556, 1.0,3.0)) is False
 
 
 def test_material_image():
@@ -626,3 +628,15 @@ def test_ellisoid():
         radii=EllipsoidRadii(cartesian=[20.0, 30.0, 40.0]), fill=False, outline=True
     )
     assert repr(ell) == expected_result
+
+def test_color_from_tuple():
+    expected_result = """{
+    "rgba": [
+        0.127568,
+        0.566949,
+        0.550556,
+        1.0
+    ]
+}"""
+    tc = Color(rgba=(0.127568, 0.566949, 0.550556, 1.0))
+    assert repr(tc) == expected_result


### PR DESCRIPTION
usage example: 

https://github.com/mhaberler/jumpvis/blob/93b3b723d27aab7f3d4319cc91d06432022ddc6d/meteo.py#L124 and https://github.com/mhaberler/jumpvis/blob/93b3b723d27aab7f3d4319cc91d06432022ddc6d/meteo.py#L52-L53

