### PR TITLE
Colors/rgba/rgbaf: support tuple-shaped color lists

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -130,14 +130,14 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
         """Determines if the input is a valid color"""
         # [R, G, B] or [R, G, B, A]
         if (
-            isinstance(color, list)
+            isinstance(color, (list, tuple))
             and all([issubclass(type(v), int) for v in color])
             and (3 <= len(color) <= 4)
         ):
             return all(0 <= v <= 255 for v in color)
         # [r, g, b] or [r, g, b, a] (float)
         elif (
-            isinstance(color, list)
+            isinstance(color, (list, tuple))
             and all([issubclass(type(v), float) for v in color])
             and (3 <= len(color) <= 4)
         ):
@@ -170,6 +170,10 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
                 color = color[:]
 
             return cls(rgbaf=RgbafValue(values=color))
+
+    @classmethod
+    def from_tuple(cls, color):
+        return cls.from_list(list(color))
 
     @classmethod
     def from_hex(cls, color):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -283,6 +283,10 @@ def test_color_isvalid():
     assert Color.is_valid(0xFF322332)
     assert Color.is_valid("#FF3223")
     assert Color.is_valid("#FF322332")
+    assert Color.is_valid((255, 204, 55))
+    assert Color.is_valid((255, 204, 55, 255))
+    assert Color.is_valid((0.127568, 0.566949, 0.550556))
+    assert Color.is_valid((0.127568, 0.566949, 0.550556, 1.0))
 
 
 def test_color_isvalid_false():
@@ -295,6 +299,8 @@ def test_color_isvalid_false():
     assert Color.is_valid(-3) is False
     assert Color.is_valid("totally valid color") is False
     assert Color.is_valid("#FF322332432") is False
+    assert Color.is_valid((255, 204, 55, 255, 42)) is False
+    assert Color.is_valid((0.127568, 0.566949, 0.550556, 1.0, 3.0)) is False
 
 
 def test_material_image():
@@ -626,3 +632,29 @@ def test_ellisoid():
         radii=EllipsoidRadii(cartesian=[20.0, 30.0, 40.0]), fill=False, outline=True
     )
     assert repr(ell) == expected_result
+
+
+def test_color_rgbaf_from_tuple():
+    expected_result = """{
+    "rgbaf": [
+        0.127568,
+        0.566949,
+        0.550556,
+        1.0
+    ]
+}"""
+    tc = Color.from_tuple((0.127568, 0.566949, 0.550556, 1.0))
+    assert repr(tc) == expected_result
+
+
+def test_color_rgba_from_tuple():
+    expected_result = """{
+    "rgba": [
+        100,
+        200,
+        255,
+        255
+    ]
+}"""
+    tc = Color.from_tuple((100, 200, 255))
+    assert repr(tc) == expected_result


### PR DESCRIPTION
usage example:

https://github.com/mhaberler/jumpvis/blob/93b3b723d27aab7f3d4319cc91d06432022ddc6d/meteo.py#L124 and https://github.com/mhaberler/jumpvis/blob/93b3b723d27aab7f3d4319cc91d06432022ddc6d/meteo.py#L52-L53

sorry, hat a missing rebase