### PR TITLE
Revert "make PolylineArrowMaterial() actually work"

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -41,7 +41,7 @@ class PolylineGlowMaterial(BaseCZMLObject):
 class PolylineArrowMaterial(BaseCZMLObject):
     """"A material that fills the surface of a line with an arrow."""
 
-    polylineArrow = attr.ib(default=None)
+    color = attr.ib(default=None)
 
 
 @attr.s(repr=False, frozen=True, kw_only=True)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -179,20 +179,16 @@ def test_material_solid_color():
 
 def test_arrowmaterial_color():
     expected_result = """{
-    "polylineArrow": {
-        "color": {
-            "rgba": [
-                200,
-                100,
-                30,
-                255
-            ]
-        }
+    "color": {
+        "rgba": [
+            200,
+            100,
+            30,
+            255
+        ]
     }
 }"""
-    pamat = PolylineArrowMaterial(
-        polylineArrow=SolidColorMaterial.from_list([200, 100, 30])
-    )
+    pamat = PolylineArrowMaterial(color=Color(rgba=[200, 100, 30, 255]))
 
     assert repr(pamat) == expected_result
 


### PR DESCRIPTION
Reverts poliastro/czml3#77.

According to https://github.com/AnalyticalGraphicsInc/czml-writer/issues/181#issuecomment-745598944, we got this one wrong.

The reason might be that we are conflating `Polyline`, `PolylineMaterial` and `PolylineArrowMaterial`, and also mixing the property names with the types.

In particular:

> `Color` is also correct here. Materials do not contain other materials.

See this fragment for an example:

https://github.com/lyqh-ctx/cesiumTx/blob/f6788936274f23c5b1d53671b25c1bcdc78db6e4/examples/czml_polyline.html#L81-L100

cc @mhaberler