### PR TITLE
Update widget

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ dev =
     pytest
     pytest-cov
     pytest-mypy
+    types-python-dateutil
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/src/czml3/widget.py
+++ b/src/czml3/widget.py
@@ -79,8 +79,8 @@ class CZMLWidget:
     document = attr.ib(default=Document([Preamble()]))
     cesium_version = attr.ib(default="1.76")
     ion_token = attr.ib(default="")
-    terrain = attr.ib(default=TERRAIN["Cesium"])
-    imagery = attr.ib(default=IMAGERY["Bing_Aerial"])
+    terrain = attr.ib(default=TERRAIN["Ellipsoid"])
+    imagery = attr.ib(default=IMAGERY["OSM"])
 
     _container_id = attr.ib(factory=uuid4)
 

--- a/src/czml3/widget.py
+++ b/src/czml3/widget.py
@@ -77,7 +77,7 @@ require(['cesium'], function (Cesium) {{
 @attr.s
 class CZMLWidget:
     document = attr.ib(default=Document([Preamble()]))
-    cesium_version = attr.ib(default="1.76")
+    cesium_version = attr.ib(default="1.88")
     ion_token = attr.ib(default="")
     terrain = attr.ib(default=TERRAIN["Ellipsoid"])
     imagery = attr.ib(default=IMAGERY["OSM"])


### PR DESCRIPTION
This changes the default terrain and imagery providers so it works without a Cesium token.