### PR TITLE
Added "color" as attribute to Billboard class.

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -301,6 +301,7 @@ class Billboard(BaseCZMLObject, HasAlignment):
     show = attr.ib(default=None)
     scale = attr.ib(default=None)
     eyeOffset = attr.ib(default=None)
+    color = attr.ib(default=None)
 
 
 @attr.s(str=False, frozen=True, kw_only=True)


### PR DESCRIPTION
Not sure if "color" was omitted purposefully or by mistake from Billboard, or perhaps it was a recent addition to the CZML spec. I am proposing to add color as an attribute. I have tested this locally and it works as expected.