### PR TITLE
Add _repr_svg_()

### DIFF
--- a/src/czml3/base.py
+++ b/src/czml3/base.py
@@ -60,7 +60,15 @@ class BaseCZMLObject:
 
     def _repr_svg_(self):
         try:
-            s1, s2, s3, _, _, _, _ = self._svg()
-            return "".join((s1, s2, s3))
+            svg_elements, x_min, x_max, y_min, y_max = self._svg()
+
+            # create SVG
+            dx = x_max - x_min
+            dy = y_max - y_min
+            width = min([max([100.0, dx]), 300])
+            height = min([max([100.0, dy]), 300])
+            svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
+            svg_end = "</g></svg>"
+            return "".join((svg_start, svg_elements, svg_end))
         except NotImplementedError:
             return ""

--- a/src/czml3/base.py
+++ b/src/czml3/base.py
@@ -62,6 +62,21 @@ class BaseCZMLObject:
         try:
             svg_elements, x_min, x_max, y_min, y_max = self._svg()
 
+            # adjust SVG frame
+            if x_min == x_max and y_min == y_max:
+                x_min *= 0.99
+                y_min *= 0.99
+                x_max *= 1.01
+                y_max *= 1.01
+            else:
+                expand = 0.04
+                widest_part = max([x_max - x_min, y_max - y_min])
+                expand_amount = widest_part * expand
+                x_min -= expand_amount
+                y_min -= expand_amount
+                x_max += expand_amount
+                y_max += expand_amount
+
             # create SVG
             dx = x_max - x_min
             dy = y_max - y_min

--- a/src/czml3/base.py
+++ b/src/czml3/base.py
@@ -1,7 +1,8 @@
+from typing import Union
 import datetime as dt
 import json
 import warnings
-from enum import Enum
+from enum import Enum, auto
 from json import JSONEncoder
 
 import attr
@@ -53,3 +54,13 @@ class BaseCZMLObject:
                 obj_dict[property_name] = getattr(self, property_name)
 
         return obj_dict
+
+    def _svg(self):
+        raise NotImplementedError
+
+    def _repr_svg_(self):
+        try:
+            s1, s2, s3, _, _, _, _ = self._svg()
+            return "".join((s1, s2, s3))
+        except NotImplementedError:
+            return ""

--- a/src/czml3/core.py
+++ b/src/czml3/core.py
@@ -153,21 +153,6 @@ class Packet(BaseCZMLObject):
         if len(svg_elements) == 0:
             return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
-
         # create SVG string
         return "".join(svg_elements), x_min, x_max, y_min, y_max
 

--- a/src/czml3/core.py
+++ b/src/czml3/core.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import attr
+from typing import Tuple
 
 from .properties import Path, Point
 from .base import BaseCZMLObject
@@ -55,7 +56,7 @@ class Packet(BaseCZMLObject):
     tileset = attr.ib(default=None)
     wall = attr.ib(default=None)
 
-    def _svg(self):
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         x_min, x_max, y_min, y_max = 9999999.0, -9999999.0, 9999999.0, -9999999.0
         svg_elements = []
         for attr_name in self.__dict__.keys():
@@ -129,9 +130,7 @@ class Packet(BaseCZMLObject):
             else:
                 try:
                     (
-                        _,
                         tmp_svg_elements,
-                        _,
                         tmp_x_min,
                         tmp_x_max,
                         tmp_y_min,
@@ -152,7 +151,7 @@ class Packet(BaseCZMLObject):
                 except NotImplementedError:
                     pass
         if len(svg_elements) == 0:
-            return ""
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # frame
         if x_min == x_max and y_min == y_max:
@@ -168,15 +167,9 @@ class Packet(BaseCZMLObject):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
         # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, "".join(svg_elements), svg_end, x_min, x_max, y_min, y_max
+        return "".join(svg_elements), x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -293,9 +293,9 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
         y_coords = [y * factor for y in coords[1::3]]
         return x_coords, y_coords
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if self.cartographicRadians is None and self.cartographicDegrees is None:
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         x_coords, y_coords = self._get_xy_coords()
@@ -332,15 +332,8 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, "".join(svg_elements), svg_end, x_min, x_max, y_min, y_max
+        return "".join(svg_elements), x_min, x_max, y_min, y_max
 
 
 # noinspection PyPep8Naming
@@ -406,12 +399,12 @@ class Corridor(BaseCZMLObject):
     classificationType = attr.ib(default=None)
     zIndex = attr.ib(default=None)
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if (
             self.positions.cartographicRadians is None
             and self.positions.cartographicDegrees is None
         ):
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         (
@@ -458,15 +451,8 @@ class Corridor(BaseCZMLObject):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, svg_element, svg_end, x_min, x_max, y_min, y_max
+        return svg_element, x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
@@ -529,12 +515,12 @@ class Polygon(BaseCZMLObject):
     classificationType = attr.ib(default=None)
     zIndex = attr.ib(default=None)
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if (
             self.positions.cartographicRadians is None
             and self.positions.cartographicDegrees is None
         ):
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         x_coords, y_coords = self.positions._get_xy_coords()
@@ -579,15 +565,8 @@ class Polygon(BaseCZMLObject):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, svg_element, svg_end, x_min, x_max, y_min, y_max
+        return svg_element, x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
@@ -608,12 +587,12 @@ class Polyline(BaseCZMLObject):
     classificationType = attr.ib(default=None)
     zIndex = attr.ib(default=None)
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if (
             self.positions.cartographicRadians is None
             and self.positions.cartographicDegrees is None
         ):
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         x_coords, y_coords = self.positions._get_xy_coords()
@@ -657,15 +636,8 @@ class Polyline(BaseCZMLObject):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, svg_element, svg_end, x_min, x_max, y_min, y_max
+        return svg_element, x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
@@ -732,9 +704,9 @@ class PositionList(BaseCZMLObject, Deletable):
         y_coords = [y * factor for y in coords[1::3]]
         return x_coords, y_coords
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if self.cartographicRadians is None and self.cartographicDegrees is None:
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         x_coords, y_coords = self._get_xy_coords()
@@ -771,15 +743,8 @@ class PositionList(BaseCZMLObject, Deletable):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, "".join(svg_elements), svg_end, x_min, x_max, y_min, y_max
+        return "".join(svg_elements), x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
@@ -839,9 +804,9 @@ class Rectangle(BaseCZMLObject, Interpolatable, Deletable):
     fill = attr.ib(default=None)
     material = attr.ib(default=None)
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if self.coordinates is None:
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         deg_long0, deg_lat0, deg_long1, deg_lat1 = self.coordinates._get_xy_coords()
@@ -863,15 +828,8 @@ class Rectangle(BaseCZMLObject, Interpolatable, Deletable):
         y_min = deg_lat0 * 0.99
         x_max = deg_long1 * 1.01
         y_max = deg_lat1 * 1.01
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, svg_element, svg_end, x_min, x_max, y_min, y_max
+        return svg_element, x_min, x_max, y_min, y_max
 
 
 # noinspection PyPep8Naming
@@ -1005,12 +963,12 @@ class Wall(BaseCZMLObject):
     shadows = attr.ib(default=None)
     distanceDisplayCondition = attr.ib(default=None)
 
-    def _svg(self) -> Tuple[str, str, str, float, float, float, float]:
+    def _svg(self) -> Tuple[str, float, float, float, float]:
         if (
             self.positions.cartographicRadians is None
             and self.positions.cartographicDegrees is None
         ):
-            return "", "", "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
+            return "", 9999999.0, -9999999.0, 9999999.0, -9999999.0
 
         # get coordinates
         x_coords, y_coords = self.positions._get_xy_coords()
@@ -1054,15 +1012,8 @@ class Wall(BaseCZMLObject):
             y_min -= expand_amount
             x_max += expand_amount
             y_max += expand_amount
-        dx = x_max - x_min
-        dy = y_max - y_min
-        width = min([max([100.0, dx]), 300])
-        height = min([max([100.0, dy]), 300])
 
-        # create SVG string
-        svg_start = f'<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="{width}" height="{height}" viewBox="{x_min} {y_min} {dx} {dy}"><g transform="matrix(1,0,0,-1,0,{y_min + y_max})">'
-        svg_end = "</g></svg>"
-        return svg_start, svg_element, svg_end, x_min, x_max, y_min, y_max
+        return svg_element, x_min, x_max, y_min, y_max
 
 
 @attr.s(str=False, frozen=True, kw_only=True)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -318,21 +318,6 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
             if y > y_max:
                 y_max = y
 
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
-
         return "".join(svg_elements), x_min, x_max, y_min, y_max
 
 
@@ -437,21 +422,6 @@ class Corridor(BaseCZMLObject):
             if y > y_max:
                 y_max = y
 
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
-
         return svg_element, x_min, x_max, y_min, y_max
 
 
@@ -551,21 +521,6 @@ class Polygon(BaseCZMLObject):
             if y > y_max:
                 y_max = y
 
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
-
         return svg_element, x_min, x_max, y_min, y_max
 
 
@@ -621,21 +576,6 @@ class Polyline(BaseCZMLObject):
                 y_min = y
             if y > y_max:
                 y_max = y
-
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
 
         return svg_element, x_min, x_max, y_min, y_max
 
@@ -729,21 +669,6 @@ class PositionList(BaseCZMLObject, Deletable):
             if y > y_max:
                 y_max = y
 
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
-
         return "".join(svg_elements), x_min, x_max, y_min, y_max
 
 
@@ -823,13 +748,7 @@ class Rectangle(BaseCZMLObject, Interpolatable, Deletable):
             raise AttributeError
         svg_element = f'<polyline stroke="{colour}" fill="none" points="{points}" />'
 
-        # frame
-        x_min = deg_long0 * 0.99
-        y_min = deg_lat0 * 0.99
-        x_max = deg_long1 * 1.01
-        y_max = deg_lat1 * 1.01
-
-        return svg_element, x_min, x_max, y_min, y_max
+        return svg_element, deg_long0, deg_long1, deg_lat0, deg_lat1
 
 
 # noinspection PyPep8Naming
@@ -997,21 +916,6 @@ class Wall(BaseCZMLObject):
                 y_min = y
             if y > y_max:
                 y_max = y
-
-        # frame
-        if x_min == x_max and y_min == y_max:
-            x_min *= 0.99
-            y_min *= 0.99
-            x_max *= 1.01
-            y_max *= 1.01
-        else:
-            expand = 0.04
-            widest_part = max([x_max - x_min, y_max - y_min])
-            expand_amount = widest_part * expand
-            x_min -= expand_amount
-            y_min -= expand_amount
-            x_max += expand_amount
-            y_max += expand_amount
 
         return svg_element, x_min, x_max, y_min, y_max
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -225,7 +225,7 @@ def test_positionlist_svg():
 
 
 def test_packet_svg():
-    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="261.3599999999997" height="261.3599999999997" viewBox="3586.32 3586.32 261.3599999999997 261.3599999999997"><g transform="matrix(1,0,0,-1,0,7434.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="rgba(200,100,30,255)" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="rgba(200,100,30,255)"/><polyline stroke="rgba(0,255,0,255)" fill="none" points="3700,3700 3600,3600" /></g></svg>'
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="216.0" height="216.0" viewBox="3592.0 3592.0 216.0 216.0"><g transform="matrix(1,0,0,-1,0,7400.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="rgba(200,100,30,255)" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="rgba(200,100,30,255)"/><polyline stroke="rgba(0,255,0,255)" fill="none" points="3700,3700 3600,3600" /></g></svg>'
     p = Packet(
         id="AreaTarget/Pennsylvania",
         name="Pennsylvania",

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -22,6 +22,7 @@ from czml3.properties import (
     Orientation,
     Point,
     Polyline,
+    Polygon,
     PolylineArrow,
     PolylineArrowMaterial,
     PolylineDash,
@@ -48,6 +49,7 @@ from czml3.types import (
     Sequence,
     UnitQuaternionValue,
 )
+from czml3.core import Packet
 
 
 def test_box():
@@ -158,6 +160,153 @@ def test_polyline():
         ),
     )
     assert str(pol) == expected_result
+
+
+def test_polyline_svg():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="300" height="300" viewBox="1960.0 2960.0 1080.0 1080.0"><g transform="matrix(1,0,0,-1,0,7000.0)"><polyline stroke="rgba(200,100,30,255)" fill="none" points="2000,3000 2500,3500 3000,4000" /></g></svg>'
+    pol = Polyline(
+        positions=PositionList(
+            cartographicDegrees=CartographicDegreesListValue(
+                values=[20, 30, 10, 25, 35, 10, 30, 40, 10]
+            )
+        ),
+        arcType=ArcType(arcType="GEODESIC"),
+        distanceDisplayCondition=DistanceDisplayCondition(
+            distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
+        ),
+        classificationType=ClassificationType(
+            classificationType=ClassificationTypes.CESIUM_3D_TILE
+        ),
+        material=Material(solidColor=SolidColorMaterial.from_list([200, 100, 30])),
+    )
+    str_svg = pol._repr_svg_()
+    assert str_svg == expected_result
+
+
+def test_polygon_svg():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="300" height="300" viewBox="1940.0 2940.0 1620.0 1120.0"><g transform="matrix(1,0,0,-1,0,7000.0)"><path d="M 2000,3000 L 3500,3500 L 2000,4000 z" fill="rgba(200,100,30,255)"/></g></svg>'
+    pol = Polygon(
+        positions=PositionList(
+            cartographicDegrees=CartographicDegreesListValue(
+                values=[20, 30, 10, 35, 35, 10, 20, 40, 10]
+            )
+        ),
+        material=Material(solidColor=SolidColorMaterial.from_list([200, 100, 30])),
+    )
+    str_svg = pol._repr_svg_()
+    assert expected_result == str_svg
+
+
+def test_no_svg():
+    pnt = Point(
+        show=True,
+        pixelSize=10,
+        scaleByDistance=NearFarScalar(
+            nearFarScalar=NearFarScalarValue(values=[150, 2.0, 15000000, 0.5])
+        ),
+        disableDepthTestDistance=1.2,
+        color=Color(rgba=[200, 100, 30, 255]),
+    )
+    assert pnt._repr_svg_() == ""
+
+
+def test_position_svg():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="100.0" height="100.0" viewBox="990.0 1980.0 20.0 40.0"><g transform="matrix(1,0,0,-1,0,4000.0)"><circle fill="black" cx="1000.0" cy="2000.0" r="1" /></g></svg>'
+    pos = Position(cartographicDegrees=[10.0, 20.0, 0.0])
+    str_svg = pos._repr_svg_()
+    assert str_svg == expected_result
+
+
+def test_positionlist_svg():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="108.0" height="108.0" viewBox="996.0 1096.0 108.0 108.0"><g transform="matrix(1,0,0,-1,0,2300.0)"><circle fill="black" cx="1000.0" cy="1100.0" r="1" /><circle fill="black" cx="1100" cy="1200" r="1" /></g></svg>'
+    pos = PositionList(cartographicDegrees=[10.0, 11.0, 0.0, 11, 12, 0])
+    str_svg = pos._repr_svg_()
+    assert str_svg == expected_result
+
+
+def test_packet_svg():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="261.3599999999997" height="261.3599999999997" viewBox="3586.32 3586.32 261.3599999999997 261.3599999999997"><g transform="matrix(1,0,0,-1,0,7434.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="rgba(200,100,30,255)" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="rgba(200,100,30,255)"/><polyline stroke="rgba(0,255,0,255)" fill="none" points="3700,3700 3600,3600" /></g></svg>'
+    p = Packet(
+        id="AreaTarget/Pennsylvania",
+        name="Pennsylvania",
+        position=Position(cartographicDegrees=[38, 38, 10]),
+        point=Point(
+            show=True,
+            pixelSize=10,
+            scaleByDistance=NearFarScalar(
+                nearFarScalar=NearFarScalarValue(values=[150, 2.0, 15000000, 0.5])
+            ),
+            disableDepthTestDistance=1.2,
+            color=Color(rgba=[200, 100, 30, 255]),
+        ),
+        polygon=Polygon(
+            positions=PositionList(
+                cartographicDegrees=CartographicDegreesListValue(
+                    values=[37.2, 37.3, 10, 38, 38, 10, 37.5, 36.9, 10]
+                )
+            ),
+            material=Material(solidColor=SolidColorMaterial.from_list([200, 100, 30])),
+        ),
+        polyline=Polyline(
+            material=Material(solidColor=SolidColorMaterial.from_list([0, 255, 0])),
+            positions=PositionList(
+                cartographicDegrees=CartographicDegreesListValue(
+                    values=[37, 37, 10, 36, 36, 10]
+                )
+            ),
+            arcType=ArcType(arcType="GEODESIC"),
+            distanceDisplayCondition=DistanceDisplayCondition(
+                distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
+            ),
+            classificationType=ClassificationType(
+                classificationType=ClassificationTypes.CESIUM_3D_TILE
+            ),
+        ),
+    )
+    str_svg = p._repr_svg_()
+    assert str_svg == expected_result
+
+
+def test_packet_svg_no_color():
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="261.3599999999997" height="261.3599999999997" viewBox="3586.32 3586.32 261.3599999999997 261.3599999999997"><g transform="matrix(1,0,0,-1,0,7434.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="rgba(200,100,30,255)" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="black"/><polyline stroke="black" fill="none" points="3700,3700 3600,3600" /></g></svg>'
+    p = Packet(
+        id="AreaTarget/Pennsylvania",
+        name="Pennsylvania",
+        position=Position(cartographicDegrees=[38, 38, 10]),
+        point=Point(
+            show=True,
+            pixelSize=10,
+            scaleByDistance=NearFarScalar(
+                nearFarScalar=NearFarScalarValue(values=[150, 2.0, 15000000, 0.5])
+            ),
+            disableDepthTestDistance=1.2,
+            color=Color(rgba=[200, 100, 30, 255]),
+        ),
+        polygon=Polygon(
+            positions=PositionList(
+                cartographicDegrees=CartographicDegreesListValue(
+                    values=[37.2, 37.3, 10, 38, 38, 10, 37.5, 36.9, 10]
+                )
+            ),
+            # material=Material(solidColor=SolidColorMaterial.from_list([200, 100, 30])),
+        ),
+        polyline=Polyline(
+            positions=PositionList(
+                cartographicDegrees=CartographicDegreesListValue(
+                    values=[37, 37, 10, 36, 36, 10]
+                )
+            ),
+            arcType=ArcType(arcType="GEODESIC"),
+            distanceDisplayCondition=DistanceDisplayCondition(
+                distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
+            ),
+            classificationType=ClassificationType(
+                classificationType=ClassificationTypes.CESIUM_3D_TILE
+            ),
+        ),
+    )
+    str_svg = p._repr_svg_()
+    assert str_svg == expected_result
 
 
 def test_material_solid_color():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -268,7 +268,7 @@ def test_packet_svg():
 
 
 def test_packet_svg_no_color():
-    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="261.3599999999997" height="261.3599999999997" viewBox="3586.32 3586.32 261.3599999999997 261.3599999999997"><g transform="matrix(1,0,0,-1,0,7434.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="rgba(200,100,30,255)" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="black"/><polyline stroke="black" fill="none" points="3700,3700 3600,3600" /></g></svg>'
+    expected_result = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" width="216.0" height="216.0" viewBox="3592.0 3592.0 216.0 216.0"><g transform="matrix(1,0,0,-1,0,7400.0)"><circle fill="black" cx="3800" cy="3800" r="1" /><circle fill="black" cx="3800" cy="3800" r="1" /><path d="M 3720.0000000000005,3729.9999999999995 L 3800,3800 L 3750.0,3690.0 z" fill="black"/><polyline stroke="black" fill="none" points="3700,3700 3600,3600" /></g></svg>'
     p = Packet(
         id="AreaTarget/Pennsylvania",
         name="Pennsylvania",
@@ -280,7 +280,6 @@ def test_packet_svg_no_color():
                 nearFarScalar=NearFarScalarValue(values=[150, 2.0, 15000000, 0.5])
             ),
             disableDepthTestDistance=1.2,
-            color=Color(rgba=[200, 100, 30, 255]),
         ),
         polygon=Polygon(
             positions=PositionList(


### PR DESCRIPTION
An SVG image is displayed for BaseCZMLObject() objects that have Position() or PositionList() attributes (if defined). The Colour() attribute is used if defined, else black is used.

No image is displayed for BaseCZMLObject() objects that don't have Position() or PositionList() attributes, nor for BaseCZMLObject() objects that don't have Position() or PositionList() attributes defined.

This is supported for:
- Polyline()
- Polygon()
- Position()
- PositionList()
- Packet()
- Wall()
- Corridor()

Note that the Packet() class combines all SVGs that it contains, and supports Point() and Path() classes which have their positions defined externally (i.e. within the packet and not within themselves).

An example in Jupyter lab:
```
p = Packet(
        id="AreaTarget/Pennsylvania",
        name="Pennsylvania",
        position=Position(
            cartographicDegrees=[38, 38, 10]
        ),
        point=Point(
            show=True,
            pixelSize=10,
            scaleByDistance=NearFarScalar(
                nearFarScalar=NearFarScalarValue(values=[150, 2.0, 15000000, 0.5])
            ),
            disableDepthTestDistance=1.2,
            color=Color(rgba=[200, 100, 30, 255]),
        ),
        polygon=Polygon(
positions=PositionList(
    cartographicDegrees=CartographicDegreesListValue(values=[37.2, 37.3, 10, 38, 38, 10, 37.5, 36.9, 10])
),
material=Material(solidColor=SolidColorMaterial.from_list([200, 100, 30])),
),
polyline=Polyline(
    material=Material(solidColor=SolidColorMaterial.from_list([0, 255, 0])),
    positions=PositionList(
        cartographicDegrees=CartographicDegreesListValue(values=[37, 37, 10, 36, 36, 10])
    ),
    arcType=ArcType(arcType="GEODESIC"),
    distanceDisplayCondition=DistanceDisplayCondition(
        distanceDisplayCondition=DistanceDisplayConditionValue(values=[14, 81])
    ),
    classificationType=ClassificationType(
        classificationType=ClassificationTypes.CESIUM_3D_TILE
    ),
)
    )
p
```
![image](https://github.com/poliastro/czml3/assets/62390960/46ce86f8-3d32-4f22-9b30-cabaef2f3549)
