### PR TITLE
Add interval to Position and PositionList

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -458,6 +458,7 @@ class PositionList(BaseCZMLObject, Deletable):
     cartographicRadians = attr.ib(default=None)
     cartographicDegrees = attr.ib(default=None)
     references = attr.ib(default=None)
+    interval = attr.ib(default=None)
 
 
 @attr.s(str=False, frozen=True, kw_only=True)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -256,6 +256,7 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
     cartographicDegrees = attr.ib(default=None)
     cartesianVelocity = attr.ib(default=None)
     reference = attr.ib(default=None)
+    interval = attr.ib(default=None)
 
     def __attrs_post_init__(self):
         if all(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -2,7 +2,6 @@ import datetime as dt
 
 import pytest
 
-from czml3.types import TimeInterval
 from czml3.enums import ArcTypes, ClassificationTypes, ShadowModes
 from czml3.properties import (
     ArcType,
@@ -11,7 +10,6 @@ from czml3.properties import (
     CheckerboardMaterial,
     ClassificationType,
     Color,
-    Polygon,
     DistanceDisplayCondition,
     Ellipsoid,
     EllipsoidRadii,
@@ -23,6 +21,7 @@ from czml3.properties import (
     NearFarScalar,
     Orientation,
     Point,
+    Polygon,
     Polyline,
     PolylineArrow,
     PolylineArrowMaterial,
@@ -48,6 +47,7 @@ from czml3.types import (
     IntervalValue,
     NearFarScalarValue,
     Sequence,
+    TimeInterval,
     UnitQuaternionValue,
 )
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -775,10 +775,12 @@ def test_polygon_interval():
     }
 }"""
     t = TimeInterval(
-                        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
-                        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
-                    )
-    poly = Polygon(positions=PositionList(cartographicDegrees=[10.0, 20.0, 0.0], interval=t))
+        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
+        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
+    )
+    poly = Polygon(
+        positions=PositionList(cartographicDegrees=[10.0, 20.0, 0.0], interval=t)
+    )
     assert str(poly) == expected_result
 
 
@@ -796,8 +798,10 @@ def test_polygon_interval_with_position():
     }
 }"""
     t = TimeInterval(
-                        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
-                        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
-                    )
-    poly = Polygon(positions=Position(cartographicDegrees=[10.0, 20.0, 0.0], interval=t))
+        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
+        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
+    )
+    poly = Polygon(
+        positions=Position(cartographicDegrees=[10.0, 20.0, 0.0], interval=t)
+    )
     assert str(poly) == expected_result

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -2,6 +2,7 @@ import datetime as dt
 
 import pytest
 
+from czml3.types import TimeInterval
 from czml3.enums import ArcTypes, ClassificationTypes, ShadowModes
 from czml3.properties import (
     ArcType,
@@ -10,6 +11,7 @@ from czml3.properties import (
     CheckerboardMaterial,
     ClassificationType,
     Color,
+    Polygon,
     DistanceDisplayCondition,
     Ellipsoid,
     EllipsoidRadii,
@@ -757,3 +759,24 @@ def test_color_rgba_from_tuple():
 }"""
     tc = Color.from_tuple((100, 200, 255))
     assert str(tc) == expected_result
+
+
+def test_polygon_interval():
+    """This only tests one interval"""
+
+    expected_result = """{
+    "positions": {
+        "cartographicDegrees": [
+            10.0,
+            20.0,
+            0.0
+        ],
+        "interval": "2019-03-20T12:00:00.000000Z/2019-04-20T12:00:00.000000Z"
+    }
+}"""
+    t = TimeInterval(
+                        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
+                        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
+                    )
+    poly = Polygon(positions=PositionList(cartographicDegrees=[10.0, 20.0, 0.0], interval=t))
+    assert str(poly) == expected_result

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -780,3 +780,24 @@ def test_polygon_interval():
                     )
     poly = Polygon(positions=PositionList(cartographicDegrees=[10.0, 20.0, 0.0], interval=t))
     assert str(poly) == expected_result
+
+
+def test_polygon_interval_with_position():
+    """This only tests one interval"""
+
+    expected_result = """{
+    "positions": {
+        "cartographicDegrees": [
+            10.0,
+            20.0,
+            0.0
+        ],
+        "interval": "2019-03-20T12:00:00.000000Z/2019-04-20T12:00:00.000000Z"
+    }
+}"""
+    t = TimeInterval(
+                        start=dt.datetime(2019, 3, 20, 12, tzinfo=dt.timezone.utc),
+                        end=dt.datetime(2019, 4, 20, 12, tzinfo=dt.timezone.utc),
+                    )
+    poly = Polygon(positions=Position(cartographicDegrees=[10.0, 20.0, 0.0], interval=t))
+    assert str(poly) == expected_result


### PR DESCRIPTION
- Add `interval` to `PositionList` with test `test_polygon_interval`
- Add `interval` to `Position` with test `test_polygon_interval_with_position`

Note that this only allows for adding **one** interval, not several (as seen [here](https://sandcastle.cesium.com/?src=CZML%20Polygon%20-%20Intervals%2C%20Availability.html&label=CZML)).

Perhaps this PR could close https://github.com/poliastro/czml3/issues/94 as the user requested only one interval. In this case a new issue should be opened requesting support for multiple intervals.