### PR TITLE
Add Interpolatable to PositionList

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -450,7 +450,7 @@ class DistanceDisplayCondition(BaseCZMLObject, Interpolatable, Deletable):
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
-class PositionList(BaseCZMLObject, Deletable):
+class PositionList(BaseCZMLObject, Interpolatable, Deletable):
     """A list of positions."""
 
     referenceFrame = attr.ib(default=None)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -488,6 +488,14 @@ def test_position_has_given_epoch():
     assert pos.epoch == expected_epoch
 
 
+def test_positionlist_has_given_epoch():
+    expected_epoch = dt.datetime(2019, 6, 11, 12, 26, 58, tzinfo=dt.timezone.utc)
+
+    pos = PositionList(epoch=expected_epoch, cartesian=[])
+
+    assert pos.epoch == expected_epoch
+
+
 def test_position_renders_epoch():
     expected_result = """{
     "epoch": "2019-03-20T12:00:00.000000Z",


### PR DESCRIPTION
- Add `Interpolatable` base class to `PositionList`
- Add test_positionlist_has_given_epoch

This allows PositionList to have an `epoch` etc as defined in `Interpolatable`.

Although [PositionList on czml-writer](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/PositionList) specifically states that it is not interpolatable **and** does not include an epoch property, the [path example](https://sandcastle.cesium.com/?src=CZML%20Path.html&label=CZML) on Cesium sandcastle provides an epoch property to the positions input (PositionList type). Seems to me that the documentation is incorrect here.