### PR TITLE
Add property names to _TimeTaggedCoords

### DIFF
--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -175,6 +175,21 @@ class Cartesian3Value(_TimeTaggedCoords):
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
+class Cartesian2Value(_TimeTaggedCoords):
+    """A two-dimensional Cartesian value specified as [X, Y].
+
+    If the values has two elements, the value is constant.
+    If it has three or more elements, they are time-tagged samples
+    arranged as [Time, X, Y, Time, X, Y, ...],
+    where Time is an ISO 8601 date and time string or seconds since epoch.
+
+    """
+
+    NUM_COORDS = 2
+    property_name = "cartesian2"
+
+
+@attr.s(str=False, frozen=True, kw_only=True)
 class CartographicRadiansValue(_TimeTaggedCoords):
     """A geodetic, WGS84 position specified as [Longitude, Latitude, Height].
 

--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -34,6 +34,7 @@ def format_datetime_like(dt_object):
 class _TimeTaggedCoords(BaseCZMLObject):
 
     NUM_COORDS: int
+    property_name: str
 
     values = attr.ib()
 
@@ -48,6 +49,8 @@ class _TimeTaggedCoords(BaseCZMLObject):
             )
 
     def to_json(self):
+        if hasattr(self, "property_name"):
+            return {self.property_name: list(self.values)}
         return list(self.values)
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -16,6 +16,7 @@ from czml3.properties import (
     EyeOffset,
     GridMaterial,
     ImageMaterial,
+    Label,
     Material,
     Model,
     NearFarScalar,
@@ -42,6 +43,7 @@ from czml3.properties import (
     ViewFrom,
 )
 from czml3.types import (
+    Cartesian2Value,
     Cartesian3Value,
     CartographicDegreesListValue,
     DistanceDisplayConditionValue,
@@ -848,3 +850,20 @@ def test_polygon_interval_with_position():
         positions=Position(cartographicDegrees=[10.0, 20.0, 0.0], interval=t)
     )
     assert str(poly) == expected_result
+
+
+def test_label_offset():
+    expected_result = """{
+    "show": true,
+    "style": "FILL",
+    "outlineWidth": 1.0,
+    "pixelOffset": {
+        "cartesian2": [
+            5,
+            5
+        ]
+    }
+}"""
+
+    label = Label(pixelOffset=Cartesian2Value(values=[5, 5]))
+    assert str(label) == expected_result


### PR DESCRIPTION
This PR allows for `_TimeTaggedCoords` classes to specify the name of their property in the CZML. If the property name is defined it will be used in the dumped CZML, otherwise the values passed will be used.

This fixes https://github.com/poliastro/czml3/issues/107 and allows for bypassing similar bugs (as described in the issue) in Cesium.