### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
From the [Publish to PyPi](https://github.com/poliastro/czml3/actions/runs/9666271466) action:
> [Deprecation notice: v1, v2, and v3 of the artifact actions](https://github.com/poliastro/czml3/actions/runs/9666271466/workflow)
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "python-package-distributions".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/