### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,7 +37,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Fixes [Publish Python 🐍 distribution 📦 to PyPI](https://github.com/poliastro/czml3/actions/runs/9713111295/job/26809222219#logs

EDIT: deleted the workflow so above link doesn't work, so here's a picture:
![image](https://github.com/poliastro/czml3/assets/62390960/a663db8b-e5f7-4adf-b2d3-3891cb088274)