### PR TITLE
Add test_tileset()

### DIFF
--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -618,7 +618,7 @@ class Point(BaseCZMLObject):
 
 
 @attr.s(str=False, frozen=True, kw_only=True)
-class TileSet(BaseCZMLObject):
+class Tileset(BaseCZMLObject):
     """A 3D Tiles tileset."""
 
     show = attr.ib(default=None)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -38,6 +38,7 @@ from czml3.properties import (
     ShadowMode,
     SolidColorMaterial,
     StripeMaterial,
+    TileSet,
     Uri,
     ViewFrom,
 )
@@ -866,3 +867,14 @@ def test_label_offset():
 
     label = Label(pixelOffset=Cartesian2Value(values=[5, 5]))
     assert str(label) == expected_result
+
+
+def test_tileset():
+    expected_result = """{
+    "show": true,
+    "uri": "../SampleData/Cesium3DTiles/Batched/BatchedColors/tileset.json"
+}"""
+    tileset = TileSet(
+        show=True, uri="../SampleData/Cesium3DTiles/Batched/BatchedColors/tileset.json"
+    )
+    assert str(tileset) == expected_result

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -38,7 +38,7 @@ from czml3.properties import (
     ShadowMode,
     SolidColorMaterial,
     StripeMaterial,
-    TileSet,
+    Tileset,
     Uri,
     ViewFrom,
 )
@@ -874,7 +874,7 @@ def test_tileset():
     "show": true,
     "uri": "../SampleData/Cesium3DTiles/Batched/BatchedColors/tileset.json"
 }"""
-    tileset = TileSet(
+    tileset = Tileset(
         show=True, uri="../SampleData/Cesium3DTiles/Batched/BatchedColors/tileset.json"
     )
     assert str(tileset) == expected_result


### PR DESCRIPTION
Add test for `TileSet`.

Furthermore, I think this property should be renamed to `Tileset`, which is what the [schema](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Tileset) names it. Let me know if you agree and I'll do another commit.