### PR TITLE
Tidying

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,9 @@ name: Run checks
 
 on: [pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,18 +23,21 @@ jobs:
       run: |
         ruff format
         ruff check --fix
-    - name: format all files
+    - name: trailing-whitespace
       continue-on-error: true
       run: |
         pre-commit run trailing-whitespace --all-files
+    - name: end-of-file-fixer
+      continue-on-error: true
+      run: |
         pre-commit run end-of-file-fixer --all-files
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
-        message: Lint Python using ruff
+        message: Lint files
         committer_name: GitHub Actions
         committer_email: 41898282+github-actions[bot]@users.noreply.github.com
-        add: '*.py'
+        add: '*'
 
   tox-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ruff
+        python -m pip install pre-commit
     - name: format Python files
       run: |
         ruff format

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
-        message: Lint Python and C files
+        message: Lint Python using ruff
         committer_name: GitHub Actions
         committer_email: 41898282+github-actions[bot]@users.noreply.github.com
         add: '*.py'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,22 +18,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ruff
-        python -m pip install pre-commit
     - name: format Python files
       run: |
         ruff format
         ruff check --fix
-    - name: format all files
-      run: |
-        pre-commit run trailing-whitespace --all-files
-        pre-commit run end-of-file-fixer --all-files
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
         message: Lint Python and C files
         committer_name: GitHub Actions
         committer_email: 41898282+github-actions[bot]@users.noreply.github.com
-        add: '*'
+        add: '*.py'
 
   tox-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,38 @@ name: Run checks
 on: [pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ruff
+        python -m pip install pre-commit
+    - name: format Python files
+      run: |
+        ruff format
+        ruff check --fix
+    - name: format all files
+      run: |
+        pre-commit run trailing-whitespace --all-files
+        pre-commit run end-of-file-fixer --all-files
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        message: Lint Python and C files
+        committer_name: GitHub Actions
+        committer_email: 41898282+github-actions[bot]@users.noreply.github.com
+        add: '*'
+
   tox-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,6 +22,11 @@ jobs:
       run: |
         ruff format
         ruff check --fix
+    - name: format all files
+      continue-on-error: true
+      run: |
+        pre-commit run trailing-whitespace --all-files
+        pre-commit run end-of-file-fixer --all-files
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+default_language_version:
+  python: python3.11
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer

--- a/README.rst
+++ b/README.rst
@@ -141,12 +141,6 @@ use `tox <https://tox.readthedocs.io/>`_::
 
   $ tox
 
-Before you send us a pull request, remember to reformat all the code::
-
-  $ tox -e reformat
-
-This will apply ruff and lots of love ❤️
-
 License
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ legacy_tox_ini = """
     skip_install = true
     commands =
         python -m ruff check
+        python -m ruff format --diff
         python -m build .
 
     [testenv:reformat]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import pytest
+
 from czml3.examples import simple
 
 TESTS_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -2,6 +2,7 @@ from io import StringIO
 from uuid import UUID
 
 import pytest
+
 from czml3 import CZML_VERSION, Packet, Preamble
 from czml3.enums import InterpolationAlgorithms, ReferenceFrames
 from czml3.properties import (

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,6 +1,7 @@
 import datetime as dt
 
 import pytest
+
 from czml3.enums import ArcTypes, ClassificationTypes, ShadowModes
 from czml3.properties import (
     ArcType,

--- a/tests/test_rectangle_image.py
+++ b/tests/test_rectangle_image.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 import pytest
+
 from czml3 import Document, Packet, Preamble
 from czml3.properties import ImageMaterial, Material, Rectangle, RectangleCoordinates
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,6 +2,8 @@ import datetime as dt
 
 import astropy.time
 import pytest
+from dateutil.tz import tzoffset
+
 from czml3.base import BaseCZMLObject
 from czml3.types import (
     Cartesian3Value,
@@ -20,7 +22,6 @@ from czml3.types import (
     UnitQuaternionValue,
     format_datetime_like,
 )
-from dateutil.tz import tzoffset
 
 
 def test_invalid_near_far_scalar_value():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from czml3.properties import Color
 from czml3.types import RgbafValue, RgbaValue
 from czml3.utils import get_color, get_color_list

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,4 +1,5 @@
 import pytest
+
 from czml3.widget import CZMLWidget
 
 


### PR DESCRIPTION
- Tox runs `ruff format -diff`.
- Remove suggestion to run `tox -e reformat` from readme.
- GitHub action automatically applies linting (ruff, trailing-whitespace and end-of-file-fixer) to PRs. Note that a .pre-commit-config.yaml file was added to the repo for running pre-commit. Also, bots must be given read and write permissions to make commits:
![image](https://github.com/user-attachments/assets/67d1088a-b2b0-4c2c-95e5-b24b871490d3)

