### PR TITLE
Fixes

### DIFF
--- a/src/czml3/__init__.py
+++ b/src/czml3/__init__.py
@@ -1,5 +1,5 @@
 from .core import CZML_VERSION, Document, Packet, Preamble
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 __all__ = ["Document", "Preamble", "Packet", "CZML_VERSION"]

--- a/src/czml3/core.py
+++ b/src/czml3/core.py
@@ -49,7 +49,7 @@ class Packet(BaseCZMLObject):
     for further information.
     """
 
-    id: str = Field(default=str(uuid4()))
+    id: str = Field(default_factory=uuid4)
     delete: None | bool = Field(default=None)
     name: None | str = Field(default=None)
     parent: None | str = Field(default=None)

--- a/src/czml3/core.py
+++ b/src/czml3/core.py
@@ -49,7 +49,7 @@ class Packet(BaseCZMLObject):
     for further information.
     """
 
-    id: str = Field(default_factory=uuid4)
+    id: str = Field(default_factory=lambda _: str(uuid4()))
     delete: None | bool = Field(default=None)
     name: None | str = Field(default=None)
     parent: None | str = Field(default=None)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -454,12 +454,8 @@ class PositionListOfLists(BaseCZMLObject, Deletable):
 
     referenceFrame: None | str | list[str] = Field(default=None)
     cartesian: None | Cartesian3Value = Field(default=None)
-    cartographicRadians: (
-        None | list[float] | list[list[float]]
-    ) = Field(default=None)
-    cartographicDegrees: (
-        None | list[float] | list[list[float]]
-    ) = Field(default=None)
+    cartographicRadians: None | list[float] | list[list[float]] = Field(default=None)
+    cartographicDegrees: None | list[float] | list[list[float]] = Field(default=None)
     references: None | str | list[str] = Field(default=None)
 
 
@@ -468,12 +464,12 @@ class PositionList(BaseCZMLObject, Interpolatable, Deletable):
 
     referenceFrame: None | str | list[str] = Field(default=None)
     cartesian: None | Cartesian3Value | list[float] = Field(default=None)
-    cartographicRadians: (
-        None | list[float] | CartographicRadiansListValue
-    ) = Field(default=None)
-    cartographicDegrees: (
-        None | list[float] | CartographicDegreesListValue
-    ) = Field(default=None)
+    cartographicRadians: None | list[float] | CartographicRadiansListValue = Field(
+        default=None
+    )
+    cartographicDegrees: None | list[float] | CartographicDegreesListValue = Field(
+        default=None
+    )
     references: None | str | list[str] = Field(default=None)
     interval: None | TimeInterval = Field(default=None)
     epoch: None | str | dt.datetime = Field(default=None)  # note: not documented
@@ -712,9 +708,7 @@ class NearFarScalar(BaseCZMLObject, Interpolatable, Deletable):
     less than the near distance or greater than the far distance, respectively.
     """
 
-    nearFarScalar: None | list[float] | NearFarScalarValue = Field(
-        default=None
-    )
+    nearFarScalar: None | list[float] | NearFarScalarValue = Field(default=None)
     reference: None | str = Field(default=None)
 
     @field_validator("reference")
@@ -748,9 +742,7 @@ class Orientation(BaseCZMLObject, Interpolatable, Deletable):
 
     """
 
-    unitQuaternion: None | list[float] | UnitQuaternionValue = Field(
-        default=None
-    )
+    unitQuaternion: None | list[float] | UnitQuaternionValue = Field(default=None)
     reference: None | str = Field(default=None)
     velocityReference: None | str = Field(default=None)
 

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -70,7 +70,7 @@ class PolylineOutline(BaseCZMLObject):
 
     color: None | Color | str = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | int | float = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
 
 
 class PolylineOutlineMaterial(BaseCZMLObject):
@@ -83,8 +83,8 @@ class PolylineGlow(BaseCZMLObject):
     """A definition of how a glowing polyline appears."""
 
     color: None | Color | str = Field(default=None)
-    glowPower: None | float | int = Field(default=None)
-    taperPower: None | float | int = Field(default=None)
+    glowPower: None | float = Field(default=None)
+    taperPower: None | float = Field(default=None)
 
 
 class PolylineGlowMaterial(BaseCZMLObject):
@@ -110,7 +110,7 @@ class PolylineDash(BaseCZMLObject):
 
     color: None | Color | str = Field(default=None)
     gapColor: None | Color | str = Field(default=None)
-    dashLength: None | float | int = Field(default=None)
+    dashLength: None | float = Field(default=None)
     dashPattern: None | int = Field(default=None)
 
 
@@ -141,10 +141,10 @@ class GridMaterial(BaseCZMLObject):
     """A material that fills the surface with a two-dimensional grid."""
 
     color: None | Color | str = Field(default=None)
-    cellAlpha: None | float | int = Field(default=None)
+    cellAlpha: None | float = Field(default=None)
     lineCount: None | list[int] = Field(default=None)
-    lineThickness: None | list[float] | list[int] = Field(default=None)
-    lineOffset: None | list[float] | list[int] = Field(default=None)
+    lineThickness: None | list[float] = Field(default=None)
+    lineOffset: None | list[float] = Field(default=None)
 
 
 class StripeMaterial(BaseCZMLObject):
@@ -153,8 +153,8 @@ class StripeMaterial(BaseCZMLObject):
     orientation: None | int = Field(default=None)
     evenColor: None | Color | str = Field(default=None)
     oddColor: None | Color | str = Field(default=None)
-    offset: None | float | int = Field(default=None)
-    repeat: None | float | int = Field(default=None)
+    offset: None | float = Field(default=None)
+    repeat: None | float = Field(default=None)
 
 
 class CheckerboardMaterial(BaseCZMLObject):
@@ -177,8 +177,8 @@ class ImageMaterial(BaseCZMLObject):
 class Color(BaseCZMLObject, Interpolatable, Deletable):
     """A color. The color can optionally vary over time."""
 
-    rgba: None | RgbaValue | str | list[float] | list[int] = Field(default=None)
-    rgbaf: None | RgbafValue | str | list[float] | list[int] = Field(default=None)
+    rgba: None | RgbaValue | str | list[float] = Field(default=None)
+    rgbaf: None | RgbafValue | str | list[float] = Field(default=None)
 
     @field_validator("rgba", "rgbaf")
     @classmethod
@@ -226,10 +226,10 @@ class Position(BaseCZMLObject, Interpolatable, Deletable):
     """Defines a position. The position can optionally vary over time."""
 
     referenceFrame: None | str = Field(default=None)
-    cartesian: None | Cartesian3Value | list[float] | list[int] = Field(default=None)
-    cartographicRadians: None | list[float] | list[int] = Field(default=None)
-    cartographicDegrees: None | list[float] | list[int] = Field(default=None)
-    cartesianVelocity: None | list[float] | list[int] = Field(default=None)
+    cartesian: None | Cartesian3Value | list[float] = Field(default=None)
+    cartographicRadians: None | list[float] = Field(default=None)
+    cartographicDegrees: None | list[float] = Field(default=None)
+    cartesianVelocity: None | list[float] = Field(default=None)
     reference: None | str = Field(default=None)
     interval: None | TimeInterval = Field(default=None)
     epoch: None | str | dt.datetime = Field(default=None)
@@ -272,7 +272,7 @@ class ViewFrom(BaseCZMLObject, Interpolatable, Deletable):
 
     ViewFrom can optionally vary over time."""
 
-    cartesian: None | Cartesian3Value | list[float] | list[int]
+    cartesian: None | Cartesian3Value | list[float]
     reference: None | str = Field(default=None)
 
     @field_validator("reference")
@@ -291,16 +291,16 @@ class Billboard(BaseCZMLObject, HasAlignment):
 
     image: str | Uri
     show: None | bool = Field(default=None)
-    scale: None | float | int = Field(default=None)
-    pixelOffset: None | list[float] | list[int] = Field(default=None)
-    eyeOffset: None | list[float] | list[int] = Field(default=None)
+    scale: None | float = Field(default=None)
+    pixelOffset: None | list[float] = Field(default=None)
+    eyeOffset: None | list[float] = Field(default=None)
     color: None | Color | str = Field(default=None)
 
 
 class EllipsoidRadii(BaseCZMLObject, Interpolatable, Deletable):
     """The radii of an ellipsoid."""
 
-    cartesian: None | Cartesian3Value | list[float] | list[int]
+    cartesian: Cartesian3Value | list[float]
     reference: None | str = Field(default=None)
 
     @field_validator("reference")
@@ -314,20 +314,20 @@ class Corridor(BaseCZMLObject):
     """A corridor , which is a shape defined by a centerline and width that conforms to the
     curvature of the body shape. It can can optionally be extruded into a volume."""
 
-    positions: PositionList | list[int] | list[float]
+    positions: PositionList | list[float]
     show: None | bool = Field(default=None)
-    width: float | int
-    height: None | float | int = Field(default=None)
+    width: float
+    height: None | float = Field(default=None)
     heightReference: None | HeightReference = Field(default=None)
-    extrudedHeight: None | float | int = Field(default=None)
+    extrudedHeight: None | float = Field(default=None)
     extrudedHeightReference: None | HeightReference = Field(default=None)
     cornerType: None | CornerType = Field(default=None)
-    granularity: None | float | int = Field(default=None)
+    granularity: None | float = Field(default=None)
     fill: None | bool = Field(default=None)
     material: None | Material | str = Field(default=None)
     outline: None | Color | str = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | int | float = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
     classificationType: None | ClassificationType = Field(default=None)
@@ -337,16 +337,16 @@ class Corridor(BaseCZMLObject):
 class Cylinder(BaseCZMLObject):
     """A cylinder, which is a special cone defined by length, top and bottom radius."""
 
-    length: float | int
+    length: float
     show: None | bool = Field(default=None)
-    topRadius: float | int
-    bottomRadius: float | int
+    topRadius: float
+    bottomRadius: float
     heightReference: None | HeightReference = Field(default=None)
     fill: None | bool = Field(default=None)
     material: None | Material | str = Field(default=None)
     outline: None | bool = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     numberOfVerticalLines: None | int = Field(default=None)
     slices: None | int = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
@@ -356,21 +356,21 @@ class Cylinder(BaseCZMLObject):
 class Ellipse(BaseCZMLObject):
     """An ellipse, which is a close curve, on or above Earth's surface."""
 
-    semiMajorAxis: float | int
-    semiMinorAxis: float | int
+    semiMajorAxis: float
+    semiMinorAxis: float
     show: None | bool = Field(default=None)
-    height: None | float | int = Field(default=None)
+    height: None | float = Field(default=None)
     heightReference: None | HeightReference = Field(default=None)
-    extrudedHeight: None | float | int = Field(default=None)
+    extrudedHeight: None | float = Field(default=None)
     extrudedHeightReference: None | HeightReference = Field(default=None)
-    rotation: None | float | int = Field(default=None)
-    stRotation: None | float | int = Field(default=None)
-    granularity: None | float | int = Field(default=None)
+    rotation: None | float = Field(default=None)
+    stRotation: None | float = Field(default=None)
+    granularity: None | float = Field(default=None)
     fill: None | bool = Field(default=None)
     material: None | Material | str = Field(default=None)
     outline: None | bool = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     numberOfVerticalLines: None | int = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
@@ -381,21 +381,21 @@ class Ellipse(BaseCZMLObject):
 class Polygon(BaseCZMLObject):
     """A polygon, which is a closed figure on the surface of the Earth."""
 
-    positions: Position | PositionList | list[int] | list[float]
+    positions: Position | PositionList | list[float]
     show: None | bool = Field(default=None)
     arcType: None | ArcType = Field(default=None)
-    granularity: None | float | int = Field(default=None)
+    granularity: None | float = Field(default=None)
     material: None | Material | str = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
     classificationType: None | ClassificationType = Field(default=None)
     zIndex: None | int = Field(default=None)
-    holes: None | PositionList | PositionListOfLists | list[int] | list[float] = Field(
+    holes: None | PositionList | PositionListOfLists | list[float] = Field(
         default=None
     )  # NOTE: not in documentation
     outlineColor: None | Color | str = Field(default=None)
     outline: None | bool = Field(default=None)
-    extrudedHeight: None | float | int = Field(default=None)
+    extrudedHeight: None | float = Field(default=None)
     perPositionHeight: None | bool = Field(default=None)
 
 
@@ -405,8 +405,8 @@ class Polyline(BaseCZMLObject):
     positions: PositionList
     show: None | bool = Field(default=None)
     arcType: None | ArcType = Field(default=None)
-    width: None | float | int = Field(default=None)
-    granularity: None | float | int = Field(default=None)
+    width: None | float = Field(default=None)
+    granularity: None | float = Field(default=None)
     material: (
         None
         | PolylineMaterial
@@ -491,10 +491,10 @@ class PositionListOfLists(BaseCZMLObject, Deletable):
     referenceFrame: None | str | list[str] = Field(default=None)
     cartesian: None | Cartesian3Value = Field(default=None)
     cartographicRadians: (
-        None | list[float] | list[int] | list[list[float]] | list[list[int]]
+        None | list[float] | list[list[float]]
     ) = Field(default=None)
     cartographicDegrees: (
-        None | list[float] | list[int] | list[list[float]] | list[list[int]]
+        None | list[float] | list[list[float]]
     ) = Field(default=None)
     references: None | str | list[str] = Field(default=None)
 
@@ -503,12 +503,12 @@ class PositionList(BaseCZMLObject, Interpolatable, Deletable):
     """A list of positions."""
 
     referenceFrame: None | str | list[str] = Field(default=None)
-    cartesian: None | Cartesian3Value | list[float] | list[int] = Field(default=None)
+    cartesian: None | Cartesian3Value | list[float] = Field(default=None)
     cartographicRadians: (
-        None | list[float] | list[int] | CartographicRadiansListValue
+        None | list[float] | CartographicRadiansListValue
     ) = Field(default=None)
     cartographicDegrees: (
-        None | list[float] | list[int] | CartographicDegreesListValue
+        None | list[float] | CartographicDegreesListValue
     ) = Field(default=None)
     references: None | str | list[str] = Field(default=None)
     interval: None | TimeInterval = Field(default=None)
@@ -525,17 +525,17 @@ class Ellipsoid(BaseCZMLObject):
 
     radii: EllipsoidRadii
     innerRadii: None | EllipsoidRadii = Field(default=None)
-    minimumClock: None | float | int = Field(default=None)
-    maximumClock: None | float | int = Field(default=None)
-    minimumCone: None | float | int = Field(default=None)
-    maximumCone: None | float | int = Field(default=None)
+    minimumClock: None | float = Field(default=None)
+    maximumClock: None | float = Field(default=None)
+    minimumCone: None | float = Field(default=None)
+    maximumCone: None | float = Field(default=None)
     show: None | bool = Field(default=None)
     heightReference: None | HeightReference = Field(default=None)
     fill: None | bool = Field(default=None)
     material: None | Material | str = Field(default=None)
     outline: None | bool = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     stackPartitions: None | int = Field(default=None)
     slicePartitions: None | int = Field(default=None)
     subdivisions: None | int = Field(default=None)
@@ -551,7 +551,7 @@ class Box(BaseCZMLObject):
     material: None | Material | str = Field(default=None)
     outline: None | bool = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
 
@@ -582,8 +582,8 @@ class Rectangle(BaseCZMLObject, Interpolatable, Deletable):
 class RectangleCoordinates(BaseCZMLObject, Interpolatable, Deletable):
     """A set of coordinates describing a cartographic rectangle on the surface of the ellipsoid."""
 
-    wsen: None | list[float] | list[int] = Field(default=None)
-    wsenDegrees: None | list[float] | list[int] = Field(default=None)
+    wsen: None | list[float] = Field(default=None)
+    wsenDegrees: None | list[float] = Field(default=None)
     reference: None | str = Field(default=None)
 
     @model_validator(mode="after")
@@ -610,7 +610,7 @@ class EyeOffset(BaseCZMLObject, Deletable):
 
     """
 
-    cartesian: None | Cartesian3Value | list[float] | list[int] = Field(default=None)
+    cartesian: None | Cartesian3Value | list[float] = Field(default=None)
     reference: None | str = Field(default=None)
 
     @field_validator("reference")
@@ -667,7 +667,7 @@ class Clock(BaseCZMLObject):
     """
 
     currentTime: None | str | dt.datetime = Field(default=None)
-    multiplier: None | float | int = Field(default=None)
+    multiplier: None | float = Field(default=None)
     range: None | ClockRanges = Field(default=None)
     step: None | ClockSteps = Field(default=None)
 
@@ -689,10 +689,10 @@ class Path(BaseCZMLObject):
     """
 
     show: None | bool | Sequence = Field(default=None)
-    leadTime: None | float | int = Field(default=None)
-    trailTime: None | float | int = Field(default=None)
-    width: None | float | int = Field(default=None)
-    resolution: None | float | int = Field(default=None)
+    leadTime: None | float = Field(default=None)
+    trailTime: None | float = Field(default=None)
+    width: None | float = Field(default=None)
+    resolution: None | float = Field(default=None)
     material: None | Material | str = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
 
@@ -701,15 +701,15 @@ class Point(BaseCZMLObject):
     """A point, or viewport-aligned circle."""
 
     show: None | bool = Field(default=None)
-    pixelSize: None | float | int = Field(default=None)
+    pixelSize: None | float = Field(default=None)
     heightReference: None | HeightReference = Field(default=None)
     color: None | Color | str = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     scaleByDistance: None | NearFarScalar = Field(default=None)
     translucencyByDistance: None | NearFarScalar = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
-    disableDepthTestDistance: None | float | int = Field(default=None)
+    disableDepthTestDistance: None | float = Field(default=None)
 
 
 class Tileset(BaseCZMLObject):
@@ -717,7 +717,7 @@ class Tileset(BaseCZMLObject):
 
     uri: str | Uri
     show: None | bool = Field(default=None)
-    maximumScreenSpaceError: None | float | int = Field(default=None)
+    maximumScreenSpaceError: None | float = Field(default=None)
 
 
 class Wall(BaseCZMLObject):
@@ -727,14 +727,14 @@ class Wall(BaseCZMLObject):
 
     show: None | bool = Field(default=None)
     positions: PositionList
-    minimumHeights: None | list[float] | list[int] = Field(default=None)
-    maximumHeights: None | list[float] | list[int] = Field(default=None)
-    granularity: None | float | int = Field(default=None)
+    minimumHeights: None | list[float] = Field(default=None)
+    maximumHeights: None | list[float] = Field(default=None)
+    granularity: None | float = Field(default=None)
     fill: None | bool = Field(default=None)
     material: None | Material | str = Field(default=None)
     outline: None | bool = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
 
@@ -748,7 +748,7 @@ class NearFarScalar(BaseCZMLObject, Interpolatable, Deletable):
     less than the near distance or greater than the far distance, respectively.
     """
 
-    nearFarScalar: None | list[float] | list[int] | NearFarScalarValue = Field(
+    nearFarScalar: None | list[float] | NearFarScalarValue = Field(
         default=None
     )
     reference: None | str = Field(default=None)
@@ -767,13 +767,13 @@ class Label(BaseCZMLObject, HasAlignment):
     text: None | str = Field(default=None)
     font: None | str = Field(default=None)
     style: None | LabelStyles = Field(default=None)
-    scale: None | float | int = Field(default=None)
+    scale: None | float = Field(default=None)
     showBackground: None | bool = Field(default=None)
     backgroundColor: None | Color | str = Field(default=None)
     fillColor: None | Color | str = Field(default=None)
     outlineColor: None | Color | str = Field(default=None)
-    outlineWidth: None | float | int = Field(default=None)
-    pixelOffset: None | float | int | Cartesian2Value = Field(default=None)
+    outlineWidth: None | float = Field(default=None)
+    pixelOffset: None | float | Cartesian2Value = Field(default=None)
 
 
 class Orientation(BaseCZMLObject, Interpolatable, Deletable):
@@ -784,7 +784,7 @@ class Orientation(BaseCZMLObject, Interpolatable, Deletable):
 
     """
 
-    unitQuaternion: None | list[float] | list[int] | UnitQuaternionValue = Field(
+    unitQuaternion: None | list[float] | UnitQuaternionValue = Field(
         default=None
     )
     reference: None | str = Field(default=None)
@@ -802,9 +802,9 @@ class Model(BaseCZMLObject):
 
     show: None | bool = Field(default=None)
     gltf: str
-    scale: None | float | int = Field(default=None)
-    minimumPixelSize: None | float | int = Field(default=None)
-    maximumScale: None | float | int = Field(default=None)
+    scale: None | float = Field(default=None)
+    minimumPixelSize: None | float = Field(default=None)
+    maximumScale: None | float = Field(default=None)
     incrementallyLoadTextures: None | bool = Field(default=None)
     runAnimations: None | bool = Field(default=None)
     shadows: None | ShadowMode = Field(default=None)
@@ -813,7 +813,7 @@ class Model(BaseCZMLObject):
     silhouetteSize: None | Color | str = Field(default=None)
     color: None | Color | str = Field(default=None)
     colorBlendMode: None | ColorBlendMode = Field(default=None)
-    colorBlendAmount: None | float | int = Field(default=None)
+    colorBlendAmount: None | float = Field(default=None)
     distanceDisplayCondition: None | DistanceDisplayCondition = Field(default=None)
     nodeTransformations: None | Any = Field(default=None)
     articulations: None | Any = Field(default=None)

--- a/src/czml3/properties.py
+++ b/src/czml3/properties.py
@@ -185,42 +185,6 @@ class Color(BaseCZMLObject, Interpolatable, Deletable):
     def is_valid(cls, color):
         return get_color(color)
 
-    # @classmethod
-    # def from_list(cls, color):
-    #     if all(issubclass(type(v), int) for v in color):
-    #         color = color + [255] if len(color) == 3 else color[:]
-    #         return cls(rgba=RgbaValue(values=color))
-    #     else:
-    #         color = color + [1.0] if len(color) == 3 else color[:]
-    #         return cls(rgbaf=RgbafValue(values=color))
-
-    # @classmethod
-    # def from_tuple(cls, color):
-    #     return cls.from_list(list(color))
-
-    # @classmethod
-    # def from_hex(cls, color):
-    #     if color > 0xFFFFFF:
-    #         values = [
-    #             (color & 0xFF000000) >> 24,
-    #             (color & 0x00FF0000) >> 16,
-    #             (color & 0x0000FF00) >> 8,
-    #             (color & 0x000000FF) >> 0,
-    #         ]
-    #     else:
-    #         values = [
-    #             (color & 0xFF0000) >> 16,
-    #             (color & 0x00FF00) >> 8,
-    #             (color & 0x0000FF) >> 0,
-    #             0xFF,
-    #         ]
-
-    #     return cls.from_list(values)
-
-    # @classmethod
-    # def from_str(cls, color):
-    #     return cls.from_hex(int(color.rsplit("#")[-1], 16))
-
 
 class Position(BaseCZMLObject, Interpolatable, Deletable):
     """Defines a position. The position can optionally vary over time."""

--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -22,33 +22,33 @@ else:
 TYPE_MAPPING = {bool: "boolean"}
 
 
-def get_color(color):
+def get_color(color) -> list[float]:
     """Determines if the input is a valid color"""
     if color is None or (
         isinstance(color, list)
-        and all(issubclass(type(v), int | float) for v in color)
+        and all(issubclass(type(v), float) for v in color)
         and len(color) == 4
         and (all(0 <= v <= 255 for v in color) or all(0 <= v <= 1 for v in color))
     ):
         return color
     elif (
         isinstance(color, list)
-        and all(issubclass(type(v), int | float) for v in color)
+        and all(issubclass(type(v), float) for v in color)
         and len(color) == 3
         and all(0 <= v <= 255 for v in color)
     ):
-        return color + [255]
+        return color + [255.0]
     # rgbf or rgbaf
     # if (
     #     isinstance(color, list)
-    #     and all(issubclass(type(v), int | float) for v in color)
+    #     and all(issubclass(type(v), float) for v in color)
     #     and (3 <= len(color) <= 4)
     #     and not all(0 <= v <= 1 for v in color)
     # ):
     #     raise TypeError("RGBF or RGBAF values must be between 0 and 1")
     elif (
         isinstance(color, list)
-        and all(issubclass(type(v), int | float) for v in color)
+        and all(issubclass(type(v), float) for v in color)
         and len(color) == 3
         and all(0 <= v <= 1 for v in color)
     ):
@@ -143,7 +143,7 @@ class RgbafValue(BaseCZMLObject):
 
     """
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -183,7 +183,7 @@ class RgbaValue(BaseCZMLObject):
 
     """
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -197,7 +197,7 @@ class RgbaValue(BaseCZMLObject):
             )
 
         if len(self.values) == num_coords and not all(
-            isinstance(val, int) and 0 <= val <= 255 for val in self.values
+            isinstance(val, float) and 0 <= val <= 255 for val in self.values
         ):
             raise TypeError("Color values must be integers in the range 0-255.")
 
@@ -205,7 +205,7 @@ class RgbaValue(BaseCZMLObject):
             for i in range(0, len(self.values), num_coords + 1):
                 v = self.values[i + 1 : i + num_coords + 1]
 
-                if not all(isinstance(val, int) and 0 <= val <= 255 for val in v):
+                if not all(isinstance(val, float) and 0 <= val <= 255 for val in v):
                     raise TypeError("Color values must be integers in the range 0-255.")
         return self
 
@@ -246,7 +246,7 @@ class Cartesian3Value(BaseCZMLObject):
 
     """
 
-    values: None | list[Any] = Field(default=None)
+    values: None | list[float] = Field(default=None)
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -263,7 +263,7 @@ class Cartesian3Value(BaseCZMLObject):
         return self
 
     @model_serializer
-    def custom_serializer(self) -> list[Any]:
+    def custom_serializer(self) -> list[float]:
         if self.values is None:
             return []
         return list(self.values)
@@ -279,7 +279,7 @@ class Cartesian2Value(BaseCZMLObject):
 
     """
 
-    values: None | list[Any] = Field(default=None)
+    values: None | list[float] = Field(default=None)
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -313,7 +313,7 @@ class CartographicRadiansValue(BaseCZMLObject):
 
     """
 
-    values: None | list[Any] = Field(default=None)
+    values: None | list[float] = Field(default=None)
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -347,7 +347,7 @@ class CartographicDegreesValue(BaseCZMLObject):
 
     """
 
-    values: None | list[Any] = Field(default=None)
+    values: None | list[float] = Field(default=None)
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -364,7 +364,7 @@ class CartographicDegreesValue(BaseCZMLObject):
         return self
 
     @model_serializer
-    def custom_serializer(self) -> list[Any]:
+    def custom_serializer(self) -> list[float]:
         if self.values is None:
             return []
         return self.values
@@ -387,7 +387,7 @@ class CartographicRadiansListValue(BaseCZMLObject):
     """A list of geodetic, WGS84 positions specified as [Longitude, Latitude, Height, Longitude, Latitude, Height, ...],
     where Longitude and Latitude are in radians and Height is in meters."""
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -407,7 +407,7 @@ class CartographicDegreesListValue(BaseCZMLObject):
     """A list of geodetic, WGS84 positions specified as [Longitude, Latitude, Height, Longitude, Latitude, Height, ...],
     where Longitude and Latitude are in degrees and Height is in meters."""
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -430,7 +430,7 @@ class DistanceDisplayConditionValue(BaseCZMLObject):
     where Time is an ISO 8601 date and time string or seconds since epoch.
     """
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -454,7 +454,7 @@ class NearFarScalarValue(BaseCZMLObject):
     FarDistance, FarValue, ...], where Time is an ISO 8601 date and time string or seconds since epoch.
     """
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -538,7 +538,7 @@ class UnitQuaternionValue(BaseCZMLObject):
 
     """
 
-    values: list[float] | list[int]
+    values: list[float]
 
     @model_validator(mode="after")
     def _check_values(self) -> Self:
@@ -567,7 +567,7 @@ class EpochValue(BaseCZMLObject):
 class NumberValue(BaseCZMLObject):
     """A single number, or a list of number pairs signifying the time and representative value."""
 
-    values: int | float | list[float] | list[int]
+    values: int | float | list[float] | int | list[int]
 
     @model_serializer
     def custom_serializer(self):

--- a/src/czml3/types.py
+++ b/src/czml3/types.py
@@ -22,7 +22,7 @@ else:
 TYPE_MAPPING = {bool: "boolean"}
 
 
-def get_color(color) -> list[float]:
+def get_color(color) -> list[float] | None:
     """Determines if the input is a valid color"""
     if color is None or (
         isinstance(color, list)

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -611,3 +611,8 @@ def test_packet_polygon():
     )
 
     assert str(packet) == expected_result
+
+def test_different_IDs():
+    p1 = Packet()
+    p2 = Packet()
+    assert p1.id != p2.id

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -612,6 +612,7 @@ def test_packet_polygon():
 
     assert str(packet) == expected_result
 
+
 def test_different_IDs():
     p1 = Packet()
     p2 = Packet()

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -28,7 +28,7 @@ from czml3.properties import (
     PositionList,
     SolidColorMaterial,
 )
-from czml3.types import Cartesian3Value, StringValue
+from czml3.types import Cartesian3Value, Sequence, StringValue
 
 
 def test_preamble_has_proper_id_and_expected_version():
@@ -617,3 +617,11 @@ def test_different_IDs():
     p1 = Packet()
     p2 = Packet()
     assert p1.id != p2.id
+    assert str(p1.id) != str(p2.id)
+
+
+def test_different_availabilities():
+    p1 = Packet(availability=Sequence(values=[1, 2, 3]))
+    p2 = Packet(availability=Sequence(values=[2, 3, 4]))
+    assert p1 != p2
+    assert str(p1) != str(p2)

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -89,10 +89,10 @@ def test_packet_label():
         },
         "outlineColor": {
             "rgba": [
-                0,
-                233,
-                255,
-                2
+                0.0,
+                233.0,
+                255.0,
+                2.0
             ]
         },
         "outlineWidth": 2.0
@@ -253,8 +253,8 @@ def test_packet_custom_properties():
         "ellipsoid": {
             "radii": {
                 "cartesian": [
-                    6378137,
-                    6378137,
+                    6378137.0,
+                    6378137.0,
                     6356752.31414
                 ]
             }
@@ -295,10 +295,10 @@ def test_packet_point():
     "point": {
         "color": {
             "rgba": [
-                255,
-                0,
-                0,
-                255
+                255.0,
+                0.0,
+                0.0,
+                255.0
             ]
         }
     }
@@ -314,22 +314,22 @@ def test_packet_polyline():
     "polyline": {
         "positions": {
             "cartographicDegrees": [
-                -75,
-                43,
-                500000,
-                -125,
-                43,
-                500000
+                -75.0,
+                43.0,
+                500000.0,
+                -125.0,
+                43.0,
+                500000.0
             ]
         },
         "material": {
             "solidColor": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 }
             }
@@ -357,33 +357,33 @@ def test_packet_polyline_outline():
     "polyline": {
         "positions": {
             "cartographicDegrees": [
-                -75,
-                43,
-                500000,
-                -125,
-                43,
-                500000
+                -75.0,
+                43.0,
+                500000.0,
+                -125.0,
+                43.0,
+                500000.0
             ]
         },
         "material": {
             "polylineOutline": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 },
                 "outlineColor": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 },
-                "outlineWidth": 2
+                "outlineWidth": 2.0
             }
         }
     }
@@ -414,22 +414,22 @@ def test_packet_polyline_glow():
     "polyline": {
         "positions": {
             "cartographicDegrees": [
-                -75,
-                43,
-                500000,
-                -125,
-                43,
-                500000
+                -75.0,
+                43.0,
+                500000.0,
+                -125.0,
+                43.0,
+                500000.0
             ]
         },
         "material": {
             "polylineGlow": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 },
                 "glowPower": 0.2,
@@ -463,22 +463,22 @@ def test_packet_polyline_arrow():
     "polyline": {
         "positions": {
             "cartographicDegrees": [
-                -75,
-                43,
-                500000,
-                -125,
-                43,
-                500000
+                -75.0,
+                43.0,
+                500000.0,
+                -125.0,
+                43.0,
+                500000.0
             ]
         },
         "material": {
             "polylineArrow": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 }
             }
@@ -506,22 +506,22 @@ def test_packet_polyline_dashed():
     "polyline": {
         "positions": {
             "cartographicDegrees": [
-                -75,
-                43,
-                500000,
-                -125,
-                43,
-                500000
+                -75.0,
+                43.0,
+                500000.0,
+                -125.0,
+                43.0,
+                500000.0
             ]
         },
         "material": {
             "polylineDash": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 }
             }
@@ -571,10 +571,10 @@ def test_packet_polygon():
             "solidColor": {
                 "color": {
                     "rgba": [
-                        255,
-                        0,
-                        0,
-                        255
+                        255.0,
+                        0.0,
+                        0.0,
+                        255.0
                     ]
                 }
             }

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1209,3 +1209,10 @@ def test_rectangle_coordinates_delete():
     "delete": true
 }"""
     )
+
+
+def test_different_positions():
+    pos1 = Position(cartographicDegrees=[1, 2, 3])
+    pos2 = Position(cartographicRadians=[1, 2, 3])
+    assert pos1 != pos2
+    assert str(pos1) != str(pos2)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -74,9 +74,9 @@ def test_box():
     "show": true,
     "dimensions": {
         "cartesian": [
-            5,
-            6,
-            3
+            5.0,
+            6.0,
+            3.0
         ]
     }
 }"""
@@ -90,9 +90,9 @@ def test_box():
 def test_eyeOffset():
     expected_result = """{
     "cartesian": [
-        1,
-        2,
-        3
+        1.0,
+        2.0,
+        3.0
     ]
 }"""
 
@@ -103,7 +103,7 @@ def test_eyeOffset():
 def test_point():
     expected_result = """{
     "show": true,
-    "pixelSize": 10,
+    "pixelSize": 10.0,
     "scaleByDistance": {
         "nearFarScalar": [
             150.0,
@@ -146,9 +146,9 @@ def test_polyline():
     expected_result = """{
     "positions": {
         "cartographicDegrees": [
-            20,
-            30,
-            10
+            20.0,
+            30.0,
+            10.0
         ]
     },
     "arcType": {
@@ -156,8 +156,8 @@ def test_polyline():
     },
     "distanceDisplayCondition": {
         "distanceDisplayCondition": [
-            14,
-            81
+            14.0,
+            81.0
         ]
     },
     "classificationType": {
@@ -184,10 +184,10 @@ def test_material_solid_color():
     "solidColor": {
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         }
     }
@@ -207,10 +207,10 @@ def test_arrowmaterial_color():
     "polylineArrow": {
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         }
     }
@@ -227,21 +227,21 @@ def test_dashmaterial_colors():
     "polylineDash": {
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         },
         "gapColor": {
             "rgba": [
-                100,
-                200,
-                0,
-                255
+                100.0,
+                200.0,
+                0.0,
+                255.0
             ]
         },
-        "dashLength": 16,
+        "dashLength": 16.0,
         "dashPattern": 255
     }
 }"""
@@ -262,10 +262,10 @@ def test_glowmaterial_color():
     "polylineGlow": {
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         },
         "glowPower": 0.7,
@@ -285,21 +285,21 @@ def test_outline_material_colors():
     "polylineOutline": {
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         },
         "outlineColor": {
             "rgba": [
-                100,
-                200,
-                0,
-                255
+                100.0,
+                200.0,
+                0.0,
+                255.0
             ]
         },
-        "outlineWidth": 3
+        "outlineWidth": 3.0
     }
 }"""
     omat = PolylineOutlineMaterial(
@@ -316,9 +316,9 @@ def test_positionlist_epoch():
     expected_result = """{
     "epoch": "2019-06-11T12:26:58.000000Z",
     "cartographicDegrees": [
-        200,
-        100,
-        30
+        200.0,
+        100.0,
+        30.0
     ]
 }"""
     p = PositionList(
@@ -413,10 +413,10 @@ def test_material_image():
         ],
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         }
     }
@@ -442,10 +442,10 @@ def test_material_image_uri():
         ],
         "color": {
             "rgba": [
-                200,
-                100,
-                30,
-                255
+                200.0,
+                100.0,
+                30.0,
+                255.0
             ]
         }
     }
@@ -467,10 +467,10 @@ def test_material_grid():
     expected_result = """{
     "color": {
         "rgba": [
-            20,
-            20,
-            30,
-            255
+            20.0,
+            20.0,
+            30.0,
+            255.0
         ]
     },
     "cellAlpha": 1.0,
@@ -532,29 +532,29 @@ def test_material_stripe():
     expected_result = """{
     "evenColor": {
         "rgba": [
-            0,
-            0,
-            0,
-            255
+            0.0,
+            0.0,
+            0.0,
+            255.0
         ]
     },
     "oddColor": {
         "rgba": [
-            255,
-            255,
-            255,
-            255
+            255.0,
+            255.0,
+            255.0,
+            255.0
         ]
     },
     "offset": 0.3,
-    "repeat": 4
+    "repeat": 4.0
 }"""
 
     pol_mat = StripeMaterial(
         evenColor=Color(rgba=[0, 0, 0]),
         oddColor=Color(rgba=[255, 255, 255]),
         offset=0.3,
-        repeat=4,
+        repeat=4.0,
     )
     assert str(pol_mat) == expected_result
 
@@ -563,18 +563,18 @@ def test_material_checkerboard():
     expected_result = """{
     "evenColor": {
         "rgba": [
-            0,
-            0,
-            0,
-            255
+            0.0,
+            0.0,
+            0.0,
+            255.0
         ]
     },
     "oddColor": {
         "rgba": [
-            255,
-            255,
-            255,
-            255
+            255.0,
+            255.0,
+            255.0,
+            255.0
         ]
     },
     "repeat": 4
@@ -662,7 +662,7 @@ def test_position_cartographic_degrees():
 def test_position_reference():
     expected_result = """{
     "cartesian": [
-        0
+        0.0
     ],
     "reference": "this#satellite"
 }"""
@@ -686,9 +686,9 @@ def test_viewfrom_reference():
 def test_viewfrom_cartesian():
     expected_result = """{
     "cartesian": [
-        -1000,
-        0,
-        300
+        -1000.0,
+        0.0,
+        300.0
     ]
 }"""
     v = ViewFrom(cartesian=Cartesian3Value(values=[-1000, 0, 300]))
@@ -776,10 +776,10 @@ def test_multiple_interval_decimal_value():
 def test_orientation():
     expected_result = """{
     "unitQuaternion": [
-        0,
-        0,
-        0,
-        1
+        0.0,
+        0.0,
+        0.0,
+        1.0
     ]
 }"""
 
@@ -849,20 +849,20 @@ def test_ellipsoid_parameters():
     "material": {
         "solidColor": {
             "rgba": [
-                255,
-                0,
-                0,
-                100
+                255.0,
+                0.0,
+                0.0,
+                100.0
             ]
         }
     },
     "outline": true,
     "outlineColor": {
         "rgbaf": [
-            0,
-            0,
-            0,
-            1
+            0.0,
+            0.0,
+            0.0,
+            1.0
         ]
     }
 }"""
@@ -953,24 +953,24 @@ def test_polygon_outline():
         "solidColor": {
             "color": {
                 "rgba": [
-                    255,
-                    100,
-                    0,
-                    100
+                    255.0,
+                    100.0,
+                    0.0,
+                    100.0
                 ]
             }
         }
     },
     "outlineColor": {
         "rgba": [
-            0,
-            0,
-            0,
-            255
+            0.0,
+            0.0,
+            0.0,
+            255.0
         ]
     },
     "outline": true,
-    "extrudedHeight": 0,
+    "extrudedHeight": 0.0,
     "perPositionHeight": true
 }"""
     poly = Polygon(
@@ -1019,8 +1019,8 @@ def test_label_offset():
     expected_result = """{
     "pixelOffset": {
         "cartesian2": [
-            5,
-            5
+            5.0,
+            5.0
         ]
     }
 }"""
@@ -1045,8 +1045,8 @@ def test_check_classes_with_references():
         str(ViewFrom(cartesian=[0, 0], reference="this#that"))
         == """{
     "cartesian": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1055,8 +1055,8 @@ def test_check_classes_with_references():
         str(EllipsoidRadii(cartesian=[0, 0], reference="this#that"))
         == """{
     "cartesian": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1072,8 +1072,8 @@ def test_check_classes_with_references():
         str(Position(cartesian=[0, 0], reference="this#that"))
         == """{
     "cartesian": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1082,10 +1082,10 @@ def test_check_classes_with_references():
         str(Orientation(unitQuaternion=[0, 0, 0, 0], reference="this#that"))
         == """{
     "unitQuaternion": [
-        0,
-        0,
-        0,
-        0
+        0.0,
+        0.0,
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1094,8 +1094,8 @@ def test_check_classes_with_references():
         str(NearFarScalar(nearFarScalar=[0, 0], reference="this#that"))
         == """{
     "nearFarScalar": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1133,8 +1133,8 @@ def test_check_classes_with_references():
         str(EyeOffset(cartesian=[0, 0], reference="this#that"))
         == """{
     "cartesian": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1143,8 +1143,8 @@ def test_check_classes_with_references():
         str(RectangleCoordinates(wsen=[0, 0], reference="this#that"))
         == """{
     "wsen": [
-        0,
-        0
+        0.0,
+        0.0
     ],
     "reference": "this#that"
 }"""
@@ -1157,9 +1157,9 @@ def test_check_classes_with_references():
         )
         == """{
     "cartesian": [
-        0,
-        0,
-        1
+        0.0,
+        0.0,
+        1.0
     ],
     "reference": "this#that"
 }"""
@@ -1175,9 +1175,9 @@ def test_check_classes_with_references():
         )
         == """{
     "distanceDisplayCondition": [
-        0,
-        1,
-        2
+        0.0,
+        1.0,
+        2.0
     ],
     "reference": "this#that"
 }"""

--- a/tests/test_rectangle_image.py
+++ b/tests/test_rectangle_image.py
@@ -26,7 +26,7 @@ def test_rectangle_coordinates_invalid_if_nothing_given():
 
 
 def test_packet_rectangles(image):
-    wsen = [20, 40, 21, 41]
+    wsen = [20.0, 40.0, 21.0, 41.0]
 
     expected_result = """{{
     "id": "id_00",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,15 +43,15 @@ def test_distance_display_condition_is_invalid():
 
 def test_distance_display_condition():
     expected_result = """[
-    0,
-    150,
-    15000000,
-    300,
-    10000,
-    15000000,
-    600,
-    150,
-    15000000
+    0.0,
+    150.0,
+    15000000.0,
+    300.0,
+    10000.0,
+    15000000.0,
+    600.0,
+    150.0,
+    15000000.0
 ]"""
     dist = DistanceDisplayConditionValue(
         values=[0, 150, 15000000, 300, 10000, 15000000, 600, 150, 15000000]
@@ -61,9 +61,9 @@ def test_distance_display_condition():
 
 def test_cartographic_radian_list():
     expected_result = """[
-    0,
-    1,
-    0
+    0.0,
+    1.0,
+    0.0
 ]"""
     car = CartographicRadiansListValue(values=[0, 1, 0])
     assert str(car) == expected_result
@@ -80,9 +80,9 @@ def test_invalid_cartograpic_radian_list():
 
 def test_cartograpic_degree_list():
     expected_result = """[
-    15,
-    25,
-    50
+    15.0,
+    25.0,
+    50.0
 ]"""
     car = CartographicDegreesListValue(values=[15, 25, 50])
     assert str(car) == expected_result
@@ -162,7 +162,7 @@ def test_bad_rgba_4_values_raises_error():
 
 def test_bad_rgba_5_color_values_raises_error():
     with pytest.raises(TypeError) as excinfo:
-        RgbaValue(values=[0, 0.1, 0.3, 0.3, 255])
+        RgbaValue(values=[0, 0.1, 0.3, 0.3, 256])
 
     assert "Color values must be integers in the range 0-255." in excinfo.exconly()
 
@@ -317,10 +317,10 @@ def test_quaternion_value_is_invalid():
 
 def test_quaternion_value():
     expected_result = """[
-    0,
-    0,
-    0,
-    1
+    0.0,
+    0.0,
+    0.0,
+    1.0
 ]"""
 
     result = UnitQuaternionValue(values=[0, 0, 0, 1])
@@ -333,19 +333,19 @@ def test_cartographic_radians_value():
     assert (
         str(result)
         == """[
-    0,
-    0,
-    0,
-    1
+    0.0,
+    0.0,
+    0.0,
+    1.0
 ]"""
     )
     result = CartographicRadiansValue(values=[0, 0, 1])
     assert (
         str(result)
         == """[
-    0,
-    0,
-    1
+    0.0,
+    0.0,
+    1.0
 ]"""
     )
     result = CartographicRadiansValue()
@@ -359,19 +359,19 @@ def test_cartographic_degrees_value():
     assert (
         str(result)
         == """[
-    0,
-    0,
-    0,
-    1
+    0.0,
+    0.0,
+    0.0,
+    1.0
 ]"""
     )
     result = CartographicDegreesValue(values=[0, 0, 1])
     assert (
         str(result)
         == """[
-    0,
-    0,
-    1
+    0.0,
+    0.0,
+    1.0
 ]"""
     )
     result = CartographicDegreesValue()
@@ -384,20 +384,20 @@ def test_rgba_value():
     assert (
         str(RgbaValue(values=[30, 30, 30, 30]))
         == """[
-    30,
-    30,
-    30,
-    30
+    30.0,
+    30.0,
+    30.0,
+    30.0
 ]"""
     )
     assert (
         str(RgbaValue(values=[30, 30, 30, 30, 1]))
         == """[
-    30,
-    30,
-    30,
-    30,
-    1
+    30.0,
+    30.0,
+    30.0,
+    30.0,
+    1.0
 ]"""
     )
 


### PR DESCRIPTION
Critical fix: ensure ID of each `core.Packet()` is unique (via `uuid.uuid4()`). Added `test_different_positions()` and `test_different_IDs()` to check this mechanism.

Minor fix: remove type options `int` and `list[int]` types from variables that should only be of type `float` and `list[float]` respectively. Note that pydantic converts ints to floats as necessary.

Bumps to v2.0.1.